### PR TITLE
Don't explicitly point to travis

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -17,4 +17,4 @@ PRGDIR=`dirname "$PRG"`
 BASEDIR=`cd "$PRGDIR/.." >/dev/null; pwd`
 
 cd $BASEDIR/idris-jvm-ffi
-travis/idris --install idris-jvm-ffi.ipkg
+idris --install idris-jvm-ffi.ipkg


### PR DESCRIPTION
That travis directory is not included and probably the corresponding binary would not work on an end-users machine.
[This line in `.travis.yml`](https://github.com/mmhelloworld/idris-jvm/blob/master/.travis.yml#L20) puts the `travis` directory on the path, so hopefully it should not be needed to specify it here.