### PR TITLE
#79 Compile Blodwen for JVM

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+indent_style = space
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Idris
 *.ibc
+.idrisjvmtypes*
 
 # IDE
 .idea

--- a/idris-jvm-core/src/main/idris/IdrisJvm/Core/Asm.idr
+++ b/idris-jvm-core/src/main/idris/IdrisJvm/Core/Asm.idr
@@ -94,28 +94,10 @@ Show InferredType where
     show IUnknown = "unknown"
 
 Semigroup InferredType where
-  IUnknown <+> known = known
-  known <+> IUnknown = known
   ty1 <+> ty2 = if ty1 == ty2 then ty1 else inferredObjectType
 
 Monoid InferredType where
   neutral = IUnknown
-
-toFrameLocalVarType : InferredType -> String
-toFrameLocalVarType IBool = "INTEGER"
-toFrameLocalVarType IByte = "INTEGER"
-toFrameLocalVarType IChar = "INTEGER"
-toFrameLocalVarType IShort = "INTEGER"
-toFrameLocalVarType IInt = "INTEGER"
-toFrameLocalVarType ILong = "LONG"
-toFrameLocalVarType IFloat = "FLOAT"
-toFrameLocalVarType IDouble = "DOUBLE"
-toFrameLocalVarType (Ref clsName) = clsName
-toFrameLocalVarType (IArray elemTy) = "[" ++ toFrameLocalVarType elemTy
-toFrameLocalVarType _ = "java/lang/Object"
-
-toFrameLocalVarTypes : InferredTypeStore -> List String
-toFrameLocalVarTypes types = toFrameLocalVarType <$> (values types)
 
 isPrimitive : InferredType -> Bool
 isPrimitive IBool = True

--- a/idris-jvm-core/src/main/idris/IdrisJvm/Core/Foreign.idr
+++ b/idris-jvm-core/src/main/idris/IdrisJvm/Core/Foreign.idr
@@ -116,32 +116,6 @@ typeDescriptorToInferredType (ThrowableDescriptor _) = inferredObjectType
 typeDescriptorToInferredType VoidDescriptor          = IUnknown
 typeDescriptorToInferredType (FieldDescriptor fieldTyDesc) = fieldTypeDescriptorToInferredType fieldTyDesc
 
-loadJavaVar : Int -> FieldTypeDescriptor -> Asm ()
-loadJavaVar index FieldTyDescBoolean = Iload index
-loadJavaVar index FieldTyDescByte    = Iload index
-loadJavaVar index FieldTyDescShort   = Iload index
-loadJavaVar index FieldTyDescInt     = Iload index
-loadJavaVar index FieldTyDescChar    = Iload index
-loadJavaVar index FieldTyDescLong    = Lload index
-loadJavaVar index FieldTyDescFloat   = Fload index
-loadJavaVar index FieldTyDescDouble  = Dload index
-loadJavaVar index (FieldTyDescReference (IdrisExportDesc cname)) = do
-  Aload index
-  InvokeMethod InvokeVirtual cname "getValue" "()Ljava/lang/Object;" False
-  checkcast idrisObjectType
-loadJavaVar index _                  = Aload index
-
-storeJavaVar : Int -> FieldTypeDescriptor -> Asm ()
-storeJavaVar index FieldTyDescBoolean = Istore index
-storeJavaVar index FieldTyDescByte    = Istore index
-storeJavaVar index FieldTyDescShort   = Istore index
-storeJavaVar index FieldTyDescInt     = Istore index
-storeJavaVar index FieldTyDescChar    = Istore index
-storeJavaVar index FieldTyDescLong    = Lstore index
-storeJavaVar index FieldTyDescFloat   = Fstore index
-storeJavaVar index FieldTyDescDouble  = Dstore index
-storeJavaVar index _                  = Astore index
-
 idrisToJava : List (FieldTypeDescriptor, LVar) -> Asm ()
 idrisToJava vars = do
     locTypes <- GetFunctionLocTypes

--- a/idris-jvm-core/src/main/java/IdrisJvm/Core/Assembler.java
+++ b/idris-jvm-core/src/main/java/IdrisJvm/Core/Assembler.java
@@ -261,6 +261,7 @@ public class Assembler {
         cws.entrySet().parallelStream().forEach(e -> {
             String className = e.getKey();
             ClassWriter classWriter = e.getValue();
+            LOGGER.info(" writing class file {} in directory {}", className, outputClassFileDir);
             File outFile = new File(outputClassFileDir, className + ".class");
             new File(outFile.getParent()).mkdirs();
             try (OutputStream out = new FileOutputStream(outFile)) {

--- a/idris-jvm-core/src/main/java/IdrisJvm/Core/IdrisToJavaNameConverter.java
+++ b/idris-jvm-core/src/main/java/IdrisJvm/Core/IdrisToJavaNameConverter.java
@@ -94,7 +94,8 @@ public class IdrisToJavaNameConverter {
         if (className.isEmpty()) {
             return DEFAULT_CLASS_NAME;
         } else if (className.contains(".")) {
-            return className.replaceAll("\\.", "/");
+            return className.replaceAll("\\.", "/")
+                    .replaceAll("([^/]+)/", "I\\$$1/");
         } else {
             return DEFAULT_PACKAGE_NAME + "/" + className;
         }

--- a/idris-jvm-ffi/src/main/idris/IdrisJvm/Data/Buffer.idr
+++ b/idris-jvm-ffi/src/main/idris/IdrisJvm/Data/Buffer.idr
@@ -1,0 +1,171 @@
+module IdrisJvm.Data.Buffer
+
+import IdrisJvm.IO
+import IdrisJvm.File
+import Java.Nio
+
+%hide Prelude.File.File
+
+-- JVM version of Idris Data.Buffer
+
+namespace IdrisBuffer
+  idrisBufferClass : String
+  idrisBufferClass = "io/github/mmhelloworld/idrisjvm/runtime/IdrisBuffer"
+
+  IdrisBufferClass : JVM_NativeTy
+  IdrisBufferClass = Class idrisBufferClass
+
+  IdrisBuffer : Type
+  IdrisBuffer = JVM_Native IdrisBufferClass
+
+||| A buffer is a pointer to a sized, unstructured, mutable chunk of memory.
+||| There are primitive operations for getting and setting bytes, ints (32 bit)
+||| and strings at a location in the buffer. These operations silently fail
+||| if the location is out of bounds, so bounds checking should be done in
+||| advance.
+export
+record Buffer where
+  constructor MkBuffer
+  ||| Raw bytes, as a pointer to a block of memory
+  rawdata : IdrisBuffer
+  ||| Cached size of block
+  buf_size : Int
+  ||| Next location to read/write (e.g. when reading from file)
+  location : Int
+
+||| Create a new buffer 'size' bytes long. Returns 'Nothing' if allocation
+||| fails
+export
+newBuffer : (size : Int) -> JVM_IO (Maybe Buffer)
+newBuffer size = do bptr <- FFI.new (Int -> JVM_IO IdrisBuffer) size
+                    pure (Just (MkBuffer bptr size 0))
+
+||| Reset the 'next location' pointer of the buffer to 0.
+||| The 'next location' pointer gives the location for the next file read/write
+||| so resetting this means you can write it again
+export
+resetBuffer : Buffer -> Buffer
+resetBuffer buf = record { location = 0 } buf
+
+||| Return the space available in the buffer
+export
+rawSize : Buffer -> JVM_IO Int
+rawSize b = invokeInstance "size" (IdrisBuffer -> JVM_IO Int) (rawdata b)
+
+export
+size : Buffer -> Int
+size b = buf_size b
+
+||| Set the byte at position 'loc' to 'val'.
+||| Does nothing if the location is outside the bounds of the buffer
+export
+setByte : Buffer -> (loc : Int) -> (val : Bits8) -> JVM_IO ()
+setByte b loc val = invokeInstance "setByte" (IdrisBuffer -> Int -> Bits8 -> JVM_IO ()) (rawdata b) loc val
+
+||| Set the int at position 'loc' to 'val'.
+||| Uses 4 bytes (assumes up to 32 bit Int).
+||| Does nothing if the location is outside the bounds of the buffer
+export
+setInt : Buffer -> (loc : Int) -> (val : Int) -> JVM_IO ()
+setInt b loc val = invokeInstance "setInt" (IdrisBuffer -> Int -> Int -> JVM_IO ()) (rawdata b) loc val
+
+||| Set the double at position 'loc' to 'val'.
+||| Uses 8 bytes (assumes 64 bit double).
+||| Does nothing if the location is outside the bounds of the buffer
+export
+setDouble : Buffer -> (loc : Int) -> (val : Double) -> JVM_IO ()
+setDouble b loc val = invokeInstance "setDouble" (IdrisBuffer -> Int -> Double -> JVM_IO ()) (rawdata b) loc val
+
+||| Set the byte at position 'loc' to 'val'.
+||| Does nothing if the location is out of bounds of the buffer, or the string
+||| is too long for the location
+export
+setString : Buffer -> Int -> String -> JVM_IO ()
+setString b loc val
+    = do invokeInstance "setString" (IdrisBuffer -> Int -> String -> JVM_IO ()) (rawdata b) loc val
+         pure ()
+
+||| Copy data from 'src' to 'dest'. Reads 'len' bytes starting at position
+||| 'start' in 'src', and writes them starting at position 'loc' in 'dest'.
+||| Does nothing if a location is out of bounds, or there is not enough room
+export
+copyData : (src : Buffer) -> (start, len : Int) ->
+           (dest : Buffer) -> (loc : Int) -> JVM_IO ()
+copyData src start len dest loc
+    = invokeInstance "copy" (IdrisBuffer -> Int -> Int -> IdrisBuffer -> Int -> JVM_IO ())
+              (rawdata src) start len (rawdata dest) loc
+
+||| Return the value at the given location in the buffer.
+||| Returns 0 if out of bounds.
+export
+getByte : Buffer -> (loc : Int) -> JVM_IO Bits8
+getByte b loc = invokeInstance "getByte" (IdrisBuffer -> Int -> JVM_IO Bits8) (rawdata b) loc
+
+||| Return the value at the given location in the buffer, assuming 4
+||| bytes to store the Int.
+||| Returns 0 if out of bounds.
+export
+getInt : Buffer -> (loc : Int) -> JVM_IO Int
+getInt b loc = invokeInstance "getInt" (IdrisBuffer -> Int -> JVM_IO Int) (rawdata b) loc
+
+||| Return the value at the given location in the buffer, assuming 8
+||| bytes to store the Double.
+||| Returns 0 if out of bounds.
+export
+getDouble : Buffer -> (loc : Int) -> JVM_IO Double
+getDouble b loc = invokeInstance "getDouble" (IdrisBuffer -> Int -> JVM_IO Double) (rawdata b) loc
+
+||| Return the string at the given location in the buffer, with the given
+||| length. Returns "" if out of bounds.
+export
+getString : Buffer -> (loc : Int) -> (len : Int) -> JVM_IO String
+getString b loc len = invokeInstance "getString" (IdrisBuffer -> Int -> Int -> JVM_IO String) (rawdata b) loc len
+
+||| Read 'maxbytes' into the buffer from a file, returning a new
+||| buffer with the 'locaton' pointer moved along
+export
+total
+readBufferFromFile : File -> Buffer -> (maxbytes : Int) -> JVM_IO Buffer
+readBufferFromFile (MkFile file path) buf max = do
+    numread <- invokeInstance "readFromFile" (IdrisBuffer -> FileChannel -> Int -> Int -> JVM_IO Int)
+                       (rawdata buf) file (location buf) max
+    pure (record { location $= (+numread) } buf)
+readBufferFromFile _ buf max = pure buf
+
+||| Write 'maxbytes' from the buffer from a file, returning a new
+||| buffer with the 'location' pointer moved along
+export
+total
+writeBufferToFile : File -> Buffer -> (maxbytes : Int) -> JVM_IO Buffer
+writeBufferToFile (MkFile file path) buf max
+    = do let maxwrite = size buf - location buf
+         let max' = if maxwrite < max then maxwrite else max
+         invokeInstance "writeToFile" (IdrisBuffer -> FileChannel -> Int -> Int -> JVM_IO ())
+                 (rawdata buf) file (location buf) max'
+         pure (record { location $= (+max') } buf)
+writeBufferToFile _ buf max = pure buf
+
+||| Return the contents of the buffer as a list
+export
+bufferData : Buffer -> JVM_IO (List Bits8)
+bufferData b = do let len = size b
+                  unpackTo [] len
+  where unpackTo : List Bits8 -> Int -> JVM_IO (List Bits8)
+        unpackTo acc 0 = pure acc
+        unpackTo acc loc = do val <- getByte b (loc - 1)
+                              unpackTo (val :: acc)
+                                       (assert_smaller loc (loc - 1))
+
+||| Create a new buffer, copying the contents of the old buffer to the new.
+||| Returns 'Nothing' if resizing fails
+export
+resizeBuffer : Buffer -> Int -> JVM_IO (Maybe Buffer)
+resizeBuffer old newsize
+    = do Just buf <- newBuffer newsize
+              | Nothing => pure Nothing
+         -- If the new buffer is smaller than the old one, just copy what
+         -- fits
+         let oldsize = size old
+         let len = if newsize < oldsize then newsize else oldsize
+         copyData old 0 len buf 0
+         pure (Just buf)

--- a/idris-jvm-ffi/src/main/idris/IdrisJvm/File.idr
+++ b/idris-jvm-ffi/src/main/idris/IdrisJvm/File.idr
@@ -1,0 +1,222 @@
+module IdrisJvm.File
+
+import Java.Util.Stream
+import Java.Lang
+import Java.Math
+import IdrisJvm.JvmImport
+import Data.Vect
+import Java.Nio
+import Java.IO
+import Java.Util
+import Java.Util.Concurrent
+
+%language TypeProviders
+%language ElabReflection
+
+%hide Prelude.File.File
+%hide Prelude.File.FileError
+%hide Java.IO.File.File
+
+jdkimport [
+    (stringClass, ["getBytes"]),
+    (pathsClass, ["get"]),
+    (fileChannelClass, ["open"]),
+    (filesClass, ["lines", "write", "readAttributes", "createDirectory"]),
+    (fileTimeClass, ["to"]),
+    (streamClass, ["collect"]),
+    (collectorsClass, ["joining"])
+  ]
+
+public export
+data File = MkFileStdin
+          | MkFileStdout
+          | MkFileStderr
+          | MkFile FileChannel Path
+
+public export
+FileError : Type
+FileError = Throwable
+
+export
+FileReadError : FileError
+FileReadError = believe_me $ unsafePerformIO $ IOException.new "File Read Error"
+
+export
+unableToOpenFile : String -> JVM_IO IOException
+unableToOpenFile fileName = IOException.new ("Unable to open file: " ++ fileName)
+
+export
+unableToReadFile : String -> JVM_IO IOException
+unableToReadFile fileName = IOException.new ("Unable to read file: " ++ fileName)
+
+export
+unableToWriteFile : String -> JVM_IO IOException
+unableToWriteFile fileName = IOException.new ("Unable to write file: " ++ fileName)
+
+modeToOpenOption : Mode -> List OpenOption
+modeToOpenOption Read              = [ StandardOpenOption.read ]
+modeToOpenOption WriteTruncate     = believe_me <$> [ StandardOpenOption.create, StandardOpenOption.write,
+                                        StandardOpenOption.truncateExisting ]
+modeToOpenOption Append            = believe_me <$> [ StandardOpenOption.append ]
+modeToOpenOption ReadWrite         = believe_me <$> [ StandardOpenOption.create, StandardOpenOption.read,
+                                       StandardOpenOption.write ]
+modeToOpenOption ReadWriteTruncate = believe_me <$> [ StandardOpenOption.create, StandardOpenOption.read,
+                                       StandardOpenOption.write, StandardOpenOption.truncateExisting ]
+modeToOpenOption ReadAppend        = believe_me <$> [ StandardOpenOption.read, StandardOpenOption.append ]
+
+export
+total
+openFile : (f : String) -> (m : Mode) -> JVM_IO (Either FileError File)
+openFile f m = assert_total $ do
+      path <- invokeStatic RuntimeClass "createPath" (String -> JVM_IO Path) f
+      ensureParentDir path
+      openOptions <- listToArray (modeToOpenOption m)
+      exceptionOrFile <- (fileChannelClass <.> "open(java/nio/file/Path,Array 1 i java/nio/file/OpenOption)") path openOptions
+      case exceptionOrFile of
+        Left exception => pure $ Left $ believe_me exception
+        Right Nothing => pure $ Left . believe_me $ !(unableToOpenFile f)
+        Right (Just file) => pure $ Right (MkFile file path)
+   where
+     hasWriteMode : Bool
+     hasWriteMode = case m of
+        WriteTruncate => True
+        ReadWrite => True
+        ReadWriteTruncate => True
+        _ => False
+
+     ensureParentDir : Path -> JVM_IO ()
+     ensureParentDir path =
+       if hasWriteMode then do
+         optParent <- invokeInstance "getParent" (Path -> JVM_IO (Maybe Path)) path
+         case optParent of
+            Nothing => pure ()
+            Just pathDir => do
+              _ <- invokeStatic FilesClass "createDirectories" (Path -> JVM_Array FileAttribute -> JVM_IO Path) pathDir
+                     !(newArray FileAttribute 0)
+              pure ()
+       else pure ()
+
+export
+closeFile : File -> JVM_IO ()
+closeFile (MkFile file _) = Channel.close file
+closeFile _ = pure ()
+
+export
+-- Not possible in JVM
+changeDir : String -> JVM_IO Bool
+changeDir = invokeStatic RuntimeClass "changeDir" (String -> JVM_IO Bool)
+
+export
+getTemporaryFileName : JVM_IO String
+getTemporaryFileName = invokeStatic RuntimeClass "getTemporaryFileName" (JVM_IO String)
+
+export
+chmod : String -> Int -> JVM_IO ()
+chmod f m = invokeStatic RuntimeClass "chmod" (String -> Int -> JVM_IO ()) f m
+
+export
+total
+createDir : String -> JVM_IO (Either FileError ())
+createDir d = assert_total $ do
+  path <- invokeStatic RuntimeClass "createPath" (String -> JVM_IO Path) d
+  exceptionOrPath <- (filesClass <.> "createDirectory") path !(newArray FileAttribute 0)
+  pure $ const () <$> exceptionOrPath
+
+export
+currentDir : JVM_IO String
+currentDir = invokeStatic RuntimeClass "getWorkingDir" (JVM_IO String)
+
+-- This is returning Int to conform to Idris fileSize function type
+-- even though Java's FileChannel returns long
+export
+fileSize : File -> JVM_IO (Either FileError Int)
+fileSize (MkFile f _) = do
+  exceptionOrSize <- invokeInstance "size" (FileChannel -> JVM_IO (JVM_Throwable Bits64)) f
+  case exceptionOrSize of
+    Left exception => pure $ Left $ believe_me exception
+    Right size => pure $ Right $ Long.intValue size
+fileSize _ = pure . Left . believe_me $ !(IOException.new "Cannot determine size for stdin/stdout/stderr")
+
+export
+fflush : File -> JVM_IO ()
+fflush (MkFile file _) = invokeInstance "force" (FileChannel -> Bool -> JVM_IO ()) file True
+fflush MkFileStdout = invokeStatic RuntimeClass "flushStdout" (JVM_IO ())
+fflush MkFileStderr = invokeStatic RuntimeClass "flushStderr" (JVM_IO ())
+fflush _ = pure ()
+
+||| Standard input
+export
+stdin : File
+stdin = MkFileStdin
+
+||| Standard output
+export
+stdout : File
+stdout = MkFileStdout
+
+||| Standard error
+export
+stderr : File
+stderr = MkFileStderr
+
+export
+total
+readFile : String -> JVM_IO (Either FileError String)
+readFile pathStr = assert_total $ do
+    path <- invokeStatic RuntimeClass "createPath" (String -> JVM_IO Path) pathStr
+    exceptionOrlines <- (filesClass <.> "lines(java/nio/file/Path)") path
+    case exceptionOrlines of
+      Left exception => pure $ Left exception
+      Right Nothing => pure $ Left . believe_me $ !(unableToReadFile pathStr)
+      Right (Just lines) => do
+        joiningCollector <- (collectorsClass <.!> "joining(java/lang/CharSequence)") $ believe_me !(lineSeparator)
+        pure . Right $ believe_me !((streamClass <.!> "collect") lines joiningCollector)
+
+export
+writeFile : String -> String -> JVM_IO (Either FileError ())
+writeFile file content = do
+  path <- invokeStatic RuntimeClass "createPath" (String -> JVM_IO Path) file
+  bytes <- (stringClass <.!> "getBytes(java/lang/String)") content "UTF-8"
+  exceptionOrPath <- (filesClass <.> "write(java/nio/file/Path,Array 1 byte,Array 1 i java/nio/file/OpenOption)") path
+            bytes !(newArray OpenOption 0)
+  pure $ either (const . Left . believe_me $ !(unableToWriteFile file)) (const $ Right ()) exceptionOrPath
+
+export
+fileModifiedTime : File -> JVM_IO (Either FileError Integer)
+fileModifiedTime (MkFile _ path) = do
+    attrs <- (filesClass <.!> "readAttributes(java/nio/file/Path,java/lang/Class,Array 1 java/nio/file/LinkOption)")
+               path (classLit basicFileAttributesClass) !(newArray LinkOption 0)
+    fileTime <- invokeInstance "lastModifiedTime" (BasicFileAttributes -> JVM_IO FileTime) attrs
+    seconds <- (fileTimeClass <.!> "to") fileTime TimeUnit.seconds
+    pure . Right $ believe_me $ BigInteger.valueOf seconds
+fileModifiedTime _ = pure . Left $ believe_me !(IOException.new "Cannot get file modified time for stdin, stdout or stderr")
+
+export
+fileAccessTime : File -> JVM_IO (Either FileError Integer)
+fileAccessTime (MkFile _ path) = do
+    attrs <- (filesClass <.!> "readAttributes(java/nio/file/Path,java/lang/Class,Array 1 java/nio/file/LinkOption)")
+                path (classLit basicFileAttributesClass) !(newArray LinkOption 0)
+    fileTime <- invokeInstance "lastAccessTime" (BasicFileAttributes -> JVM_IO FileTime) attrs
+    seconds <- (fileTimeClass <.!> "to") fileTime TimeUnit.seconds
+    pure . Right $ believe_me $ BigInteger.valueOf seconds
+fileAccessTime _ = pure . Left $ believe_me !(IOException.new "Cannot get file access time for stdin, stdout or stderr")
+
+export
+fileStatusTime : File -> JVM_IO (Either FileError Integer)
+fileStatusTime (MkFile _ path) = do
+    attrs <- (filesClass <.!> "readAttributes(java/nio/file/Path,java/lang/Class,Array 1 java/nio/file/LinkOption)")
+               path (classLit basicFileAttributesClass) !(newArray LinkOption 0)
+    fileTime <- invokeInstance "creationTime" (BasicFileAttributes -> JVM_IO FileTime) attrs
+    seconds <- (fileTimeClass <.!> "to") fileTime TimeUnit.seconds
+    pure . Right $ believe_me $ BigInteger.valueOf seconds
+fileStatusTime _ = pure . Left $ believe_me !(IOException.new "Cannot get file status time for stdin, stdout or stderr")
+
+||| Check if a file handle has reached the end
+export
+fEOF : File -> JVM_IO Bool
+fEOF (MkFile file _) = do
+  position <- invokeInstance "position" (FileChannel -> JVM_IO Bits64) file
+  size <- invokeInstance "size" (FileChannel -> JVM_IO Bits64) file
+  pure (position == size)
+fEOF MkFileStdin = invokeStatic RuntimeClass "isStdinEof" (JVM_IO Bool)
+fEOF _ = pure False

--- a/idris-jvm-ffi/src/main/idris/IdrisJvm/IO.idr
+++ b/idris-jvm-ffi/src/main/idris/IdrisJvm/IO.idr
@@ -21,7 +21,19 @@ getLine : JVM_IO String
 getLine = getLine'
 
 putCh : Char -> JVM_IO ()
-putCh ch = PrintStream.printCh !System.out ch
+putCh ch = PrintStream.printCh System.stdout ch
 
 getCh : JVM_IO Char
 getCh = invokeStatic RuntimeClass "readChar" (JVM_IO Char)
+
+putChar : Char -> JVM_IO ()
+putChar ch = PrintStream.printCh System.stdout ch
+
+getChar : JVM_IO Char
+getChar = invokeStatic RuntimeClass "readChar" (JVM_IO Char)
+
+jputChar : Char -> JVM_IO ()
+jputChar ch = PrintStream.printCh System.stdout ch
+
+jgetChar : JVM_IO Char
+jgetChar = invokeStatic RuntimeClass "readChar" (JVM_IO Char)

--- a/idris-jvm-ffi/src/main/idris/IdrisJvm/JvmImport.idr
+++ b/idris-jvm-ffi/src/main/idris/IdrisJvm/JvmImport.idr
@@ -1,7 +1,7 @@
 module IdrisJvm.JvmImport
 
 import System
-import IdrisJvm.FFI
+import public IdrisJvm.IO
 
 %dynamic "libc"
 

--- a/idris-jvm-ffi/src/main/idris/IdrisJvm/System.idr
+++ b/idris-jvm-ffi/src/main/idris/IdrisJvm/System.idr
@@ -6,21 +6,28 @@ import Java.Util
 import Java.Math
 import Java.Lang
 
-%access public export
-
+public export
 getArgs : JVM_IO (List String)
 getArgs = do
-    argsList <- getStaticField RuntimeClass "programArgs" (JVM_IO JList)
+    argsList <- invokeStatic RuntimeClass "getProgramArgs" (JVM_IO JList)
     Iterator.toList !(JList.iterator argsList)
 
+public export
 time : JVM_IO Integer
 time = believe_me <$> invokeStatic RuntimeClass "time" (JVM_IO BigInteger)
 
+public export
 getEnv : String -> JVM_IO (Maybe String)
 getEnv = System.getenv
 
+public export
 system : String -> JVM_IO Int
 system = invokeStatic RuntimeClass "runCommand" (String -> JVM_IO Int)
 
+public export
 usleep : (i : Int) -> { auto prf : So (i >= 0 && i <= 1000000) } -> JVM_IO ()
 usleep interval = invokeStatic RuntimeClass "usleep" (Int -> JVM_IO ()) interval
+
+public export
+exit : Int -> JVM_IO a
+exit = believe_me . Java.Lang.System.exit

--- a/idris-jvm-ffi/src/main/idris/Java/IO.idr
+++ b/idris-jvm-ffi/src/main/idris/Java/IO.idr
@@ -1,0 +1,37 @@
+module Java.IO
+
+import IdrisJvm.IO
+import Java.Lang
+
+%access public export
+
+namespace File
+    fileClass : String
+    fileClass = "java/io/File"
+
+    FileClass : JVM_NativeTy
+    FileClass = Class fileClass
+
+    File : Type
+    File = JVM_Native FileClass
+
+namespace IOException
+
+  IOException : Type
+  IOException = JVM_Native (Class "java/io/IOException")
+
+  new : String -> JVM_IO IOException
+  new = FFI.new (String -> JVM_IO IOException)
+
+namespace OutputStream
+
+  OutputStream : Type
+  OutputStream = JVM_Native (Class "java/io/OutputStream")
+
+  Inherits Closeable OutputStream where {}
+
+  Inherits Flushable OutputStream where {}
+
+namespace BufferedReader
+    BufferedReader : Type
+    BufferedReader = JVM_Native (Class "java/io/BufferedReader")

--- a/idris-jvm-ffi/src/main/idris/Java/Math.idr
+++ b/idris-jvm-ffi/src/main/idris/Java/Math.idr
@@ -25,5 +25,8 @@ namespace BigInteger
   add : BigInteger -> BigInteger -> BigInteger
   add b1 b2 = unsafePerformIO $ invokeInstance "add" (BigInteger -> BigInteger -> JVM_IO BigInteger) b1 b2
 
+  valueOf : Bits64 -> BigInteger
+  valueOf val = unsafePerformIO $ invokeStatic BigIntegerClass "valueOf" (Bits64 -> JVM_IO BigInteger) val
+
 Show BigInteger where
   show = BigInteger.toString

--- a/idris-jvm-ffi/src/main/idris/Java/Nio.idr
+++ b/idris-jvm-ffi/src/main/idris/Java/Nio.idr
@@ -1,0 +1,145 @@
+module Java.Nio
+
+import IdrisJvm.IO
+
+%access public export
+
+namespace OpenOption
+    openOptionClass : String
+    openOptionClass = "java/nio/file/OpenOption"
+
+    OpenOption : Type
+    OpenOption = JVM_Native (Interface openOptionClass)
+
+namespace StandardOpenOption
+    standardOpenOptionClass : String
+    standardOpenOptionClass = "java/nio/file/StandardOpenOption"
+
+    StandardOpenOptionClass : JVM_NativeTy
+    StandardOpenOptionClass = Class standardOpenOptionClass
+
+    StandardOpenOption : Type
+    StandardOpenOption = JVM_Native StandardOpenOptionClass
+
+    Inherits OpenOption StandardOpenOption where {}
+
+    append : StandardOpenOption
+    append = unsafePerformIO $ getStaticField StandardOpenOptionClass "APPEND" (JVM_IO StandardOpenOption)
+
+    create : StandardOpenOption
+    create = unsafePerformIO $ getStaticField StandardOpenOptionClass "CREATE" (JVM_IO StandardOpenOption)
+
+    createNew : StandardOpenOption
+    createNew = unsafePerformIO $ getStaticField StandardOpenOptionClass "CREATE_NEW" (JVM_IO StandardOpenOption)
+
+    deleteOnClose: StandardOpenOption
+    deleteOnClose = unsafePerformIO $ getStaticField StandardOpenOptionClass "DELETE_ON_CLOSE" (JVM_IO StandardOpenOption)
+
+    dsync : StandardOpenOption
+    dsync = unsafePerformIO $ getStaticField StandardOpenOptionClass "DSYNC" (JVM_IO StandardOpenOption)
+
+    read : StandardOpenOption
+    read = unsafePerformIO $ getStaticField StandardOpenOptionClass "READ" (JVM_IO StandardOpenOption)
+
+    sparse : StandardOpenOption
+    sparse = unsafePerformIO $ getStaticField StandardOpenOptionClass "SPARSE" (JVM_IO StandardOpenOption)
+
+    sync : StandardOpenOption
+    sync = unsafePerformIO $ getStaticField StandardOpenOptionClass "SYNC" (JVM_IO StandardOpenOption)
+
+    truncateExisting : StandardOpenOption
+    truncateExisting = unsafePerformIO $ getStaticField StandardOpenOptionClass "TRUNCATE_EXISTING" (JVM_IO StandardOpenOption)
+
+    write : StandardOpenOption
+    write = unsafePerformIO $ getStaticField StandardOpenOptionClass "WRITE" (JVM_IO StandardOpenOption)
+
+namespace Path
+    pathClass : String
+    pathClass = "java/nio/file/Path"
+
+    Path : Type
+    Path = JVM_Native (Interface pathClass)
+
+Show Path where
+    show path = unsafePerformIO $ invokeInstance "toString" (Path -> JVM_IO String) path
+
+namespace Files
+    filesClass : String
+    filesClass = "java/nio/file/Files"
+
+    FilesClass : JVM_NativeTy
+    FilesClass = Class filesClass
+
+    Files : Type
+    Files = JVM_Native FilesClass
+
+namespace Files
+    pathsClass : String
+    pathsClass = "java/nio/file/Paths"
+
+    PathsClass : JVM_NativeTy
+    PathsClass = Class pathsClass
+
+    Paths : Type
+    Paths = JVM_Native PathsClass
+
+namespace Channel
+    channelClass : String
+    channelClass = "java/nio/channels/Channel"
+
+    ChannelClass : JVM_NativeTy
+    ChannelClass = Interface channelClass
+
+    Channel : Type
+    Channel = JVM_Native ChannelClass
+
+    close : Inherits Channel channel => channel -> JVM_IO ()
+    close channel = invokeInstance "close" (Channel -> JVM_IO ()) (believe_me channel)
+
+namespace SeekableByteChannel
+    seekableByteChannelClass : String
+    seekableByteChannelClass = "java/nio/channels/SeekableByteChannel"
+
+    SeekableByteChannel : Type
+    SeekableByteChannel = JVM_Native (Interface seekableByteChannelClass)
+
+    Inherits Channel SeekableByteChannel where {}
+
+ namespace FileChannel
+     fileChannelClass : String
+     fileChannelClass = "java/nio/channels/FileChannel"
+
+     FileChannel : Type
+     FileChannel = JVM_Native (Class fileChannelClass)
+
+     Inherits Channel FileChannel where {}
+     Inherits SeekableByteChannel FileChannel where {}
+
+namespace FileAttribute
+    fileAttributeClass : String
+    fileAttributeClass = "java/nio/file/attribute/FileAttribute"
+
+    FileAttribute : Type
+    FileAttribute = JVM_Native (Interface fileAttributeClass)
+
+namespace BasicFileAttributes
+    basicFileAttributesClass : String
+    basicFileAttributesClass = "java/nio/file/attribute/BasicFileAttributes"
+
+    BasicFileAttributes : Type
+    BasicFileAttributes = JVM_Native (Interface basicFileAttributesClass)
+
+namespace LinkOption
+    linkOptionClass : String
+    linkOptionClass = "java/nio/file/LinkOption"
+
+    LinkOption : Type
+    LinkOption = JVM_Native (Class "java/nio/file/LinkOption")
+
+namespace FileTime
+    fileTimeClass : String
+    fileTimeClass = "java/nio/file/attribute/FileTime"
+
+    FileTime : Type
+    FileTime = JVM_Native (Class fileTimeClass)
+

--- a/idris-jvm-ffi/src/main/idris/Java/Util.idr
+++ b/idris-jvm-ffi/src/main/idris/Java/Util.idr
@@ -7,9 +7,14 @@ import Java.Util.Stream
 %access public export
 
 namespace Collection
+  collectionClass : String
+  collectionClass = "java/util/Collection"
+
+  CollectionInterface : JVM_NativeTy
+  CollectionInterface = Interface collectionClass
 
   Collection : Type
-  Collection = javaInterface "java/util/Collection"
+  Collection = JVM_Native CollectionInterface
 
   stream : Inherits Collection collection => collection -> JVM_IO JStream
   stream collection = invokeInstance "stream" (Collection -> JVM_IO JStream) (believe_me collection)
@@ -74,8 +79,14 @@ namespace Iterator
       else pure []
 
 namespace JList
+  listClass: String
+  listClass = "java/util/List"
+
+  ListInterface : JVM_NativeTy
+  ListInterface = Interface listClass
+
   JList : Type
-  JList = javaInterface "java/util/List"
+  JList = JVM_Native ListInterface
 
   Inherits Collection JList where {}
 
@@ -89,9 +100,14 @@ namespace JList
   iterator list = invokeInstance "iterator" (JList -> JVM_IO Iterator) (believe_me list)
 
 namespace ArrayList
+  arrayListClass: String
+  arrayListClass = "java/util/ArrayList"
+
+  ArrayListClass : JVM_NativeTy
+  ArrayListClass = Class arrayListClass
 
   ArrayList : Type
-  ArrayList = javaClass "java/util/ArrayList"
+  ArrayList = JVM_Native ArrayListClass
 
   Inherits Collection ArrayList where {}
   Inherits JList ArrayList where {}
@@ -133,3 +149,15 @@ namespace Objects
 
   isNull : Inherits Object that => that -> JVM_IO Bool
   isNull obj = invokeStatic ObjectsClass "isNull" (Object -> JVM_IO Bool) (believe_me obj)
+
+namespace Scanner
+    scannerClass : JVM_NativeTy
+    scannerClass = Class "java/util/Scanner"
+
+    Scanner : Type
+    Scanner = JVM_Native scannerClass
+
+    hasNext : Scanner -> JVM_IO Bool
+    hasNext = invokeInstance "hasNext" (Scanner -> JVM_IO Bool)
+
+    Inherits Closeable Scanner where {}

--- a/idris-jvm-ffi/src/main/idris/Java/Util/Concurrent.idr
+++ b/idris-jvm-ffi/src/main/idris/Java/Util/Concurrent.idr
@@ -11,6 +11,9 @@ namespace TimeUnit
   TimeUnit : Type
   TimeUnit = JVM_Native TimeUnitClass
 
+  seconds : TimeUnit
+  seconds = unsafePerformIO $ getStaticField TimeUnitClass "SECONDS" (JVM_IO TimeUnit)
+
   microseconds : TimeUnit
   microseconds = unsafePerformIO $ getStaticField TimeUnitClass "MICROSECONDS" (JVM_IO TimeUnit)
 

--- a/idris-jvm-ffi/src/main/idris/Java/Util/Stream.idr
+++ b/idris-jvm-ffi/src/main/idris/Java/Util/Stream.idr
@@ -11,6 +11,9 @@ namespace Collector
   Collector = javaInterface "java/util/stream/Collector"
 
 namespace Collectors
+  collectorsClass : String
+  collectorsClass = "java/util/stream/Collectors"
+
   CollectorsClass : JVM_NativeTy
   CollectorsClass = Class "java/util/stream/Collectors"
 
@@ -21,8 +24,11 @@ namespace Collectors
   toList = invokeStatic CollectorsClass "toList" (JVM_IO Collector)
 
 namespace JStream
+  streamClass : String
+  streamClass = "java/util/stream/Stream"
+
   JStreamInterface : JVM_NativeTy
-  JStreamInterface = Interface "java/util/stream/Stream"
+  JStreamInterface = Interface streamClass
 
   JStream : Type
   JStream = JVM_Native JStreamInterface

--- a/idris-jvm-ffi/src/main/idris/idris-jvm-ffi.ipkg
+++ b/idris-jvm-ffi/src/main/idris/idris-jvm-ffi.ipkg
@@ -2,14 +2,18 @@ package idrisjvmffi
 
 pkgs = effects
 
-modules = IdrisJvm.FFI
+modules = IdrisJvm.Data.Buffer
+        , IdrisJvm.FFI
         , IdrisJvm.IO
+        , IdrisJvm.File
         , IdrisJvm.JvmImport
         , IdrisJvm.System
         , Java.Util.Concurrent
         , Java.Util.Function
         , Java.Util.Stream
         , IdrisJvm.Effects
+        , Java.IO
         , Java.Lang
+        , Java.Nio
         , Java.Util
         , Java.Math

--- a/idris-jvm-integration-test/src/test/resources/idris-test-sources/automaticffi/automaticffi.idr
+++ b/idris-jvm-integration-test/src/test/resources/idris-test-sources/automaticffi/automaticffi.idr
@@ -3,26 +3,12 @@ module Main
 import IdrisJvm.IO
 import IdrisJvm.JvmImport
 import Java.Lang
+import Java.Util
 
 %access public export
 
 %language TypeProviders
 %language ElabReflection
-
-stringClass: String
-stringClass = "java/lang/String"
-
-listInterface: String
-listInterface = "java/util/List"
-
-arrayListClass: String
-arrayListClass = "java/util/ArrayList"
-
-collectionInterface : String
-collectionInterface = "java/util/Collection"
-
-systemClass: String
-systemClass = "java/lang/System"
 
 comparatorClass : String
 comparatorClass = "java/util/Comparator"
@@ -39,16 +25,13 @@ stringBuilderClass = "java/lang/StringBuilder"
 objectsClass : String
 objectsClass = "java/util/Objects"
 
-integerClass : String
-integerClass = "java/lang/Integer"
-
 jdkimport [
     (systemClass, ["getProperty", "setProperty"]),
     (stringClass, ["substring", "CASE_INSENSITIVE_ORDER", "valueOf"]),
     (integerClass, ["parseInt"]),
     (comparatorClass, ["compare"]),
     (arrayListClass, ["<init>", "add"]),
-    (listInterface, ["get"]),
+    (listClass, ["get"]),
     (collectionsClass, ["max"]),
     (stringBuilderClass, ["<init>", "toString"]),
     (objectsClass, ["toString"]),
@@ -66,18 +49,6 @@ IllegalArgumentExceptionClass = Class "java/lang/IllegalArgumentException"
 
 SecurityExceptionClass : JVM_NativeTy
 SecurityExceptionClass = Class "java/lang/SecurityException"
-
-ArrayListClass : JVM_NativeTy
-ArrayListClass = Class arrayListClass
-
-ListInterface : JVM_NativeTy
-ListInterface = Interface listInterface
-
-CollectionInterface : JVM_NativeTy
-CollectionInterface = Interface collectionInterface
-
-ArrayListClass inherits CollectionInterface
-ArrayListClass inherits ListInterface
 
 objectToString : Inherits Object obj => obj -> JVM_IO String
 objectToString obj = (objectsClass <.!> "toString") $ believe_me obj
@@ -99,7 +70,7 @@ main = do
 
   -- exception handling
   propValue <- try ((systemClass <.> "getProperty(?java/lang/String)") Nothing) [
-    ([catch IllegalArgumentExceptionClass, catch NullPointerExceptionClass], \t =>
+    ([jcatch IllegalArgumentExceptionClass, jcatch NullPointerExceptionClass], \t =>
         do
           printLn "property name is null or empty"
           pure Nothing
@@ -118,7 +89,7 @@ main = do
   putStrLn !(either objectToString (pure . show) noSecondCharException)
 
   s <- (stringClass <.> "substring(int)") "Foobar" 1
-  putStrLn !(either throw (pure . show) s) -- rethrowing
+  putStrLn !(either jthrow (pure . show) s) -- rethrowing
 
   -- Unsafe instance method
   printLn $ !((stringClass <.!> "substring(int)") "Foobar" 1)
@@ -131,7 +102,7 @@ main = do
 
   -- Unsafe constructor
   list <- arrayListClass <.!> "<init>()"
-  exceptionOrMaybeFirstItem <- (listInterface <.> "get") list 0
+  exceptionOrMaybeFirstItem <- (listClass <.> "get") list 0
   putStrLn !(either objectToString (maybe (pure "") objectToString) exceptionOrMaybeFirstItem)
 
   arrayList <- arrayListClass <.!> "<init>()"

--- a/idris-jvm-runtime/src/main/java/io/github/mmhelloworld/idrisjvm/runtime/IdrisBuffer.java
+++ b/idris-jvm-runtime/src/main/java/io/github/mmhelloworld/idrisjvm/runtime/IdrisBuffer.java
@@ -1,0 +1,158 @@
+package io.github.mmhelloworld.idrisjvm.runtime;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.SeekableByteChannel;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.READ;
+import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
+import static java.nio.file.StandardOpenOption.WRITE;
+
+public final class IdrisBuffer {
+
+    private final ByteBuffer buffer;
+
+    public IdrisBuffer(int size) {
+        this.buffer = ByteBuffer.allocate(size);
+    }
+
+    public int size() {
+        return buffer.capacity();
+    }
+
+    public void copy(int start, int len, IdrisBuffer to, int loc) {
+        if (loc >= 0 && loc + len <= to.size()) {
+            to.buffer.position(loc);
+            for (int i = start; i < start + len; i++) {
+                to.buffer.put(this.buffer.get(i));
+            }
+        }
+    }
+
+    public void setByte(int loc, byte b) {
+        if (loc >= 0 && loc < size()) {
+            this.buffer.put(loc, b);
+        }
+    }
+
+    public void setChar(int loc, char val) {
+        if (loc >= 0 && loc + Character.BYTES <= size()) {
+            buffer.putChar(loc, val);
+        }
+    }
+
+    public void setInt(int loc, int val) {
+        if (loc >= 0 && loc + Integer.BYTES <= size()) {
+            buffer.putInt(loc, val);
+        }
+    }
+
+    public void setDouble(int loc, double val) {
+        if (loc >= 0 && loc + Double.BYTES <= size()) {
+            buffer.putDouble(loc, val);
+        }
+    }
+
+    public void setString(int loc, String str) {
+        byte[] bytes = str.getBytes(UTF_8);
+        int len = bytes.length;
+
+        int end = loc + len;
+        if (loc >= 0 && end <= size()) {
+            buffer.position(loc);
+            int sourceIndex = 0;
+            for (int targetIndex = loc; targetIndex < end; targetIndex++) {
+                buffer.put(bytes[sourceIndex++]);
+            }
+        }
+    }
+
+    public byte getByte(int loc) {
+        if (loc >= 0 && loc < size()) {
+            return buffer.get(loc);
+        } else {
+            return 0;
+        }
+    }
+
+    public int getInt(int loc) {
+        if (loc >= 0 && loc + Integer.BYTES <= size()) {
+            return buffer.getInt(loc);
+        } else {
+            return 0;
+        }
+    }
+
+    public double getDouble(int loc) {
+        double d;
+        if (loc >= 0 && loc + Double.BYTES <= size()) {
+            return buffer.getDouble(loc);
+        } else {
+            return 0;
+        }
+    }
+
+    public String getString(int loc, int len) {
+        len = loc >= 0 && loc + len <= size() ? len : 0;
+        if (len == 0) {
+            return "";
+        }
+        byte[] data = new byte[len];
+        int targetIndex = 0;
+        for (int i = loc; i < loc + len; i++) {
+            data[targetIndex++] = buffer.get(i);
+        }
+        return new String(data, UTF_8);
+    }
+
+    int readFromFile(File file, int loc, int len) throws IOException {
+        return readFromFile(FileChannel.open(file.toPath(), READ), loc, len);
+    }
+
+    public void writeToFile(File file, int loc, int len) throws IOException {
+        writeToFile(FileChannel.open(file.toPath(), WRITE, CREATE, TRUNCATE_EXISTING), loc, len);
+    }
+
+    public int readFromFile(FileChannel file, int loc, int len) throws IOException {
+        int size = size();
+        if (loc >= 0 && loc < size) {
+            if (loc + len > size) {
+                len = size - loc;
+            }
+            int end = loc + len;
+            buffer.position(loc);
+            byte[] data = new byte[1024];
+            int numberOfBytesRead = 0;
+            for (int index = loc; index < end; index += 1024) {
+                int limit = Math.min(end - index, 1024);
+                numberOfBytesRead += file.read(ByteBuffer.wrap(data, 0, limit));
+                buffer.put(data, 0, limit);
+            }
+            return numberOfBytesRead;
+        } else {
+            return 0;
+        }
+    }
+
+    public void writeToFile(FileChannel file, int loc, int len) throws IOException {
+        int size = size();
+        if (loc >= 0 && loc < size) {
+            if (loc + len > size) {
+                len = size - loc;
+            }
+            int end = loc + len;
+            byte[] data = new byte[1024];
+            buffer.position(loc);
+            for (int index = loc; index < end; index += 1024) {
+                int limit = Math.min(end - index, 1024);
+                buffer.get(data, 0, limit);
+                file.write(ByteBuffer.wrap(data, 0, limit));
+            }
+        }
+    }
+}

--- a/idris-jvm-runtime/src/main/java/io/github/mmhelloworld/idrisjvm/runtime/IdrisObject.java
+++ b/idris-jvm-runtime/src/main/java/io/github/mmhelloworld/idrisjvm/runtime/IdrisObject.java
@@ -174,7 +174,7 @@ public class IdrisObject {
                 return idrisObject.properties[propertyIndex - UNROLLED_PROPS_COUNT];
             }
         } else {
-            return obj;
+            return -1;
         }
     }
 

--- a/idris-jvm-runtime/src/main/java/io/github/mmhelloworld/idrisjvm/runtime/Ref.java
+++ b/idris-jvm-runtime/src/main/java/io/github/mmhelloworld/idrisjvm/runtime/Ref.java
@@ -1,0 +1,17 @@
+package io.github.mmhelloworld.idrisjvm.runtime;
+
+public class Ref {
+    private Object value;
+
+    public Ref(Object value) {
+        this.value = value;
+    }
+
+    public Object getValue() {
+        return value;
+    }
+
+    public void setValue(Object value) {
+        this.value = value;
+    }
+}

--- a/idris-jvm-runtime/src/main/java/io/github/mmhelloworld/idrisjvm/runtime/Runtime.java
+++ b/idris-jvm-runtime/src/main/java/io/github/mmhelloworld/idrisjvm/runtime/Runtime.java
@@ -1,27 +1,161 @@
 package io.github.mmhelloworld.idrisjvm.runtime;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.math.BigInteger;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Scanner;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import static java.lang.System.currentTimeMillis;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.attribute.PosixFilePermission.GROUP_EXECUTE;
+import static java.nio.file.attribute.PosixFilePermission.GROUP_READ;
+import static java.nio.file.attribute.PosixFilePermission.GROUP_WRITE;
+import static java.nio.file.attribute.PosixFilePermission.OTHERS_EXECUTE;
+import static java.nio.file.attribute.PosixFilePermission.OTHERS_READ;
+import static java.nio.file.attribute.PosixFilePermission.OTHERS_WRITE;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_EXECUTE;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_READ;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_WRITE;
 import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 
 public class Runtime {
+    private static final boolean isPosix = FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
+    private static final Map<Integer, PosixFilePermission> modeToPermissions = new HashMap<>();
     public static List<String> programArgs = emptyList();
+    private static BufferedReader stdin = new BufferedReader(new InputStreamReader(System.in, UTF_8));
+    private static String workingDir = System.getProperty("user.dir");
+    private static boolean isStdinEof = false;
 
-    private static Scanner inputScanner = new Scanner(System.in);
-
-    public static String readString() {
-        return inputScanner.nextLine();
+    static {
+        modeToPermissions.put(256, OWNER_READ);
+        modeToPermissions.put(128, OWNER_WRITE);
+        modeToPermissions.put(64, OWNER_EXECUTE);
+        modeToPermissions.put(32, GROUP_READ);
+        modeToPermissions.put(16, GROUP_WRITE);
+        modeToPermissions.put(8, GROUP_EXECUTE);
+        modeToPermissions.put(4, OTHERS_READ);
+        modeToPermissions.put(2, OTHERS_WRITE);
+        modeToPermissions.put(1, OTHERS_EXECUTE);
     }
 
-    public static char readChar() {
-        return inputScanner.nextLine().charAt(0);
+    public static boolean isStdinEof() {
+        return isStdinEof;
+    }
+
+    public static char readChar() throws IOException {
+        int ch = stdin.read();
+        isStdinEof = ch == -1;
+        return (char) ch;
+    }
+
+    public static String readString() throws IOException {
+        String line = stdin.readLine();
+        isStdinEof = line == null;
+        return line;
+    }
+
+    public static void flushStdout() {
+        System.out.flush();
+    }
+
+    public static void flushStderr() {
+        System.err.flush();
+    }
+
+    public static void setProgramArgs(String[] args) {
+        // "java" as the executable name for the first argument to conform to Idris' getArgs function
+        programArgs = Stream.concat(Stream.of("java"), Arrays.stream(args))
+                .collect(toList());
+    }
+
+    public static List<String> getProgramArgs() {
+        return programArgs;
+    }
+
+    public static String getTemporaryFileName() throws IOException {
+        String prefix = "idris";
+        Path tempFile = Files.createTempFile(prefix, null);
+        tempFile.toFile().delete();
+        return tempFile.toString();
+    }
+
+    public static void chmod(String file, int mode) throws IOException {
+        if (isPosix) {
+            Files.setPosixFilePermissions(createPath(file), createPosixFilePermissions(mode));
+        }
+    }
+
+    public static boolean changeDir(String dir) {
+        workingDir = createPath(dir).toString();
+        return true;
+    }
+
+    public static String getWorkingDir() {
+        return workingDir;
+    }
+
+    public static String showThrowable(Throwable throwable) {
+        StringWriter out = new StringWriter();
+        throwable.printStackTrace(new PrintWriter(out));
+        return out.toString();
+    }
+
+    public static Path createPath(String pathStr) {
+        Path path = Paths.get(pathStr);
+        if (path.isAbsolute()) {
+            return path;
+        } else {
+            if (pathStr.equals(".")) {
+                return Paths.get(workingDir);
+            } else if (pathStr.equals("..")) {
+                return Paths.get(workingDir).getParent();
+            } else {
+                return Paths.get(workingDir, pathStr);
+            }
+        }
+    }
+
+    public static String systemInfo(int index) {
+        switch (index) {
+            case 0:
+                return "jvm";
+            case 1:
+                return System.getProperty("os.name");
+            default:
+                return "";
+        }
+    }
+
+    public static Object crash(String message) {
+        System.err.println(message);
+        System.exit(1);
+        return null;
+    }
+
+    private static Set<PosixFilePermission> createPosixFilePermissions(int mode) {
+        return modeToPermissions.entrySet().stream()
+                .filter(modeAndPermission -> (mode & modeAndPermission.getKey()) == modeAndPermission.getKey())
+                .map(Entry::getValue)
+                .collect(toSet());
     }
 
     public static Integer writeString(Object s) {
@@ -55,13 +189,17 @@ public class Runtime {
     }
 
     public static int constructorIndex(Object obj) {
+        final int constructor;
         if (obj == null) {
-            return 0;
+            constructor = -1;
         } else if (obj instanceof IdrisObject) {
-            return ((IdrisObject) obj).constructorId;
+            constructor = ((IdrisObject) obj).constructorId;
+        } else if (obj instanceof Integer) {
+            constructor = (int) obj;
         } else {
-            return (int) obj;
+            constructor = 0;
         }
+        return constructor;
     }
 
     public static BigInteger time() {

--- a/idris-jvm-runtime/src/main/java/io/github/mmhelloworld/idrisjvm/runtime/Util.java
+++ b/idris-jvm-runtime/src/main/java/io/github/mmhelloworld/idrisjvm/runtime/Util.java
@@ -94,6 +94,8 @@ public class Util {
     public static int toInt(Object that) {
         if (that instanceof Integer) {
             return (int) that;
+        } else if (that instanceof BigInteger) {
+            return ((BigInteger) that).intValueExact();
         } else if (that instanceof Character) {
             return (char) that;
         } else if (that instanceof Boolean) {
@@ -110,6 +112,7 @@ public class Util {
 
     public static boolean toBoolean(Object that) {
         if (that == null) {
+            System.out.println("null in toBoolean");
             return false;
         } else if (that instanceof Integer) {
             return ((Integer) that) != 0;

--- a/idris-jvm-server/src/main/java/io/github/mmhelloworld/idrisjvm/CodegenController.java
+++ b/idris-jvm-server/src/main/java/io/github/mmhelloworld/idrisjvm/CodegenController.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -35,7 +36,6 @@ import static java.util.Collections.emptyList;
 import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
 import static org.objectweb.asm.Opcodes.ACC_STATIC;
 import static org.objectweb.asm.Opcodes.INVOKESTATIC;
-import static org.objectweb.asm.Opcodes.PUTSTATIC;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
 
 @RestController
@@ -54,6 +54,7 @@ public class CodegenController implements ApplicationListener<EmbeddedServletCon
 
     @RequestMapping(method = POST)
     public void compile(@RequestBody String[] args) {
+        LOGGER.info("Processing with args: " + Arrays.toString(args));
         JsonFactory jsonfactory = new JsonFactory();
         jsonfactory.setCodec(mapper);
         List<String> argsList = stripArgs(asList(args));
@@ -152,8 +153,7 @@ public class CodegenController implements ApplicationListener<EmbeddedServletCon
             emptyList(), emptyList());
         assembler.methodCodeStart();
         assembler.aload(0);
-        assembler.invokeMethod(INVOKESTATIC, "java/util/Arrays", "asList", "([Ljava/lang/Object;)Ljava/util/List;", false);
-        assembler.field(PUTSTATIC, "io/github/mmhelloworld/idrisjvm/runtime/Runtime", "programArgs", "Ljava/util/List;");
+        assembler.invokeMethod(INVOKESTATIC, "io/github/mmhelloworld/idrisjvm/runtime/Runtime", "setProgramArgs", "([Ljava/lang/String;)V", false);
         assembler.invokeMethod(INVOKESTATIC, classAndMethodName[0], classAndMethodName[1], "()Lio/github/mmhelloworld/idrisjvm/runtime/Thunk;", false);
         assembler.pop();
         assembler.asmReturn();


### PR DESCRIPTION
* Support for Blodwen
* Implement shift left and shift right for BigInteger, `LSystemInfo`, `LCrash`
* Fix generated package names not to clash with classes
* Add `IdrisJvm.Data.Buffer` module, equivalent to Idris C back end `Data.Buffer` module
* Add support for `IORef`
* Add `IdrisJvm.File` module, equivalent to Idris C back end `Prelude.File` module
