### PR TITLE
Fix for #81.

### DIFF
--- a/idris-jvm-ffi/src/main/idris/IdrisJvm/File.idr
+++ b/idris-jvm-ffi/src/main/idris/IdrisJvm/File.idr
@@ -169,7 +169,7 @@ readFile pathStr = assert_total $ do
       Right Nothing => pure $ Left . believe_me $ !(unableToReadFile pathStr)
       Right (Just lines) => do
         joiningCollector <- (collectorsClass <.!> "joining(java/lang/CharSequence)") $ believe_me !(lineSeparator)
-        pure . Right $ believe_me !((streamClass <.!> "collect") lines joiningCollector)
+        pure . Right $ believe_me !((streamClass <.!> "collect(java/util/stream/Collector)") lines joiningCollector)
 
 export
 writeFile : String -> String -> JVM_IO (Either FileError ())

--- a/idris-jvm-ffi/src/main/idris/IdrisJvm/JvmImport.idr
+++ b/idris-jvm-ffi/src/main/idris/IdrisJvm/JvmImport.idr
@@ -153,7 +153,7 @@ jvmImport cmd importList = do
     system cmd
     Right str <- readFile ".idrisjvmtypes"
         | Left err => pure (Error $ show err)
-    let errOrffiDescs = sequence $ parseJvmOutput <$> (filter (not . (== "")) $ lines str)
+    let errOrffiDescs = sequence $ parseJvmOutput <$> (filter (/= "") $ lines str)
     pure $ either Error Provide errOrffiDescs
   where
 
@@ -175,7 +175,7 @@ jvmImport cmd importList = do
       | _ = Left $ "Unable to parse invocation type: " ++ invStr
 
     parseJvmOutput : String -> Either String JvmFfiDesc
-    parseJvmOutput desc = case filter (not . (== "")) $ Strings.split (== ',') desc of
+    parseJvmOutput desc = case filter (/= "") $ Strings.split (== ',') desc of
       "c" :: returns :: args => do
         jtype <- parseEType returns
         args <- parseArgs args
@@ -438,7 +438,7 @@ j ffiDescs safety ty fname = do
         ". Did you forget to import?"]
 
       argTypes : Elab (String, Maybe (List EType))
-      argTypes = case filter (not . (== "")) $ Strings.split (== '(') fname of
+      argTypes = case filter (/= "") $ Strings.split (== '(') fname of
         [methodName] => pure (methodName, Nothing)
         methodName :: rest :: _ => case Strings.split (== ')') rest of
           "" :: _ => pure (methodName, Just [])

--- a/idris-jvm-ffi/src/main/idris/IdrisJvm/JvmImport.idr
+++ b/idris-jvm-ffi/src/main/idris/IdrisJvm/JvmImport.idr
@@ -3,7 +3,7 @@ module IdrisJvm.JvmImport
 import System
 import public IdrisJvm.IO
 
-%dynamic "libc"
+%dynamic "libc", "msvcrt"
 
 %access public export
 
@@ -153,7 +153,7 @@ jvmImport cmd importList = do
     system cmd
     Right str <- readFile ".idrisjvmtypes"
         | Left err => pure (Error $ show err)
-    let errOrffiDescs = sequence $ parseJvmOutput <$> lines str
+    let errOrffiDescs = sequence $ parseJvmOutput <$> (filter (not . (== "")) $ lines str)
     pure $ either Error Provide errOrffiDescs
   where
 


### PR DESCRIPTION
TypeProvider now runs under windows. Need to filter empty lines in JVM output and provide type information for Stream.collect (since it is overloaded).