### PR TITLE
Use 0.6.0, update install action to include self hosting build, restrict logging to debugging function

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -12,7 +12,7 @@ on:
 env:
   IDRIS2_TESTS_CG: jvm
   ACTIONS_ALLOW_UNSECURE_COMMANDS: true
-  PREVIOUS_VERSION: 0.5.1.2
+  PREVIOUS_VERSION: 0.6.0
 
 jobs:
   build:

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -42,3 +42,18 @@ jobs:
 
       - name: Build
         run: mvn -B install -Dinteractive= -Didris.tests=only=jvm
+
+      - name: Copy new version
+        run: |
+          mkdir -p "$HOME/bin/idris2-current"
+          cp -r build/exec "$HOME/bin/idris2-current/exec"
+          cp -r build/env "$HOME/bin/idris2-current/env"
+
+      - name: Use new version
+        run: |
+          echo "::add-path::$HOME/bin/idris2-current/exec"
+          echo IDRIS2_PREFIX="$HOME/bin/idris2-current/env" >> "$GITHUB_ENV"
+          echo PREFIX="$IDRIS2_PREFIX" >> "$GITHUB_ENV"
+
+      - name: Self host
+        run: mvn -B clean install -Dinteractive= -Didris.tests=only=jvm

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -8,7 +8,7 @@ on:
 env:
   IDRIS2_TESTS_CG: jvm
   ACTIONS_ALLOW_UNSECURE_COMMANDS: true
-  PREVIOUS_VERSION: 0.5.1.2
+  PREVIOUS_VERSION: 0.6.0
 
 jobs:
   pre-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ on:
 env:
   IDRIS2_TESTS_CG: jvm
   ACTIONS_ALLOW_UNSECURE_COMMANDS: true
-  PREVIOUS_VERSION: 0.5.1.2
+  PREVIOUS_VERSION: 0.6.0
 
 jobs:
   release:

--- a/src/Compiler/Jvm/Codegen.idr
+++ b/src/Compiler/Jvm/Codegen.idr
@@ -1732,9 +1732,8 @@ assembleDefinition idrisName fc = do
         lineNumberLabels := lineNumberLabels }
     updateCurrentFunction $ { dynamicVariableCounter := 0 }
     let optimizedExpr = optimizedBody function
-    debug $ "Assembling " ++ declaringClassName ++ "." ++ methodName
-    let shouldDebugExpr = shouldDebug && (debugFunction `isInfixOf` (getSimpleName jname))
-    when shouldDebugExpr $ debug $ showNamedCExp 0 optimizedExpr
+    when (shouldDebugFunction jname) $ logAsm $ "Assembling " ++ declaringClassName ++ "." ++ methodName ++ "\n" ++
+      showNamedCExp 0 optimizedExpr
     let fileName = fst $ getSourceLocationFromFc fc
     let descriptor = getMethodDescriptor functionType
     -- Cache only top level nil arity functions. Don't cache extracted function results.


### PR DESCRIPTION
* Use 0.6.0 for github actions
* Update install action to include self hosting build. This will ensure new changes can successfully build the compiler.
*  Restrict logging to debugging function. This will avoid noise in the log when debugging optimizations and bytecode.