### PR TITLE
Fix TCO, split root trampoline function into multiple to avoid JVM method size limit

### DIFF
--- a/src/Compiler/Jvm/Jname.idr
+++ b/src/Compiler/Jvm/Jname.idr
@@ -26,6 +26,7 @@ assemblerClass name = "io/github/mmhelloworld/idrisjvm/assembler/" ++ name
 export
 cleanupIdentifier : String -> String
 
+export
 %foreign "jvm:.replace,java/lang/String"
 replace : String -> Char -> Char -> String
 


### PR DESCRIPTION
* Split root trampoline function into multiple to avoid JVM method size limit