### PR TITLE
Reduce boxing by using Idris function types

### DIFF
--- a/idris-jvm-runtime/src/main/java/io/github/mmhelloworld/idrisjvm/runtime/Conversion.java
+++ b/idris-jvm-runtime/src/main/java/io/github/mmhelloworld/idrisjvm/runtime/Conversion.java
@@ -23,8 +23,6 @@ public final class Conversion {
             return 0;
         } else if (that instanceof Integer) {
             return (int) that;
-        } else if (that instanceof Thunk) {
-            return ((Thunk) that).getInt();
         } else if (that instanceof BigInteger) {
             return ((BigInteger) that).intValue();
         } else if (that instanceof Long) {

--- a/idris-jvm-runtime/src/main/java/io/github/mmhelloworld/idrisjvm/runtime/Runtime.java
+++ b/idris-jvm-runtime/src/main/java/io/github/mmhelloworld/idrisjvm/runtime/Runtime.java
@@ -1,5 +1,7 @@
 package io.github.mmhelloworld.idrisjvm.runtime;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.lang.management.ManagementFactory;
 import java.nio.channels.Channels;
 import java.util.List;
@@ -116,6 +118,18 @@ public final class Runtime {
 
     public static String getErrorMessage(int errorNumber) {
         return "Error code: " + errorNumber;
+    }
+
+    public static String getStackTraceString() {
+        StackTraceElement[] trace = new Throwable().getStackTrace();
+        StringWriter stringWriter = new StringWriter();
+        PrintWriter printWriter = new PrintWriter(stringWriter, true);
+        for (int index = 1; index < trace.length; index++) {
+            StackTraceElement traceElement = trace[index];
+            printWriter.println("\tat " + traceElement);
+        }
+        printWriter.flush();
+        return stringWriter.toString();
     }
 
     public static void free(Object object) {

--- a/libs/base/System.idr
+++ b/libs/base/System.idr
@@ -271,7 +271,7 @@ namespace Escaped
 
 %foreign supportC "idris2_time"
          "javascript:lambda:() => Math.floor(new Date().getTime() / 1000)"
-         "jvm:time(java/lang/Object int),io/github/mmhelloworld/idrisjvm/runtime/IdrisSystem"
+         "jvm:time(int),io/github/mmhelloworld/idrisjvm/runtime/IdrisSystem"
 prim__time : PrimIO Int
 
 ||| Return the number of seconds since epoch.

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     </developers>
 
     <properties>
-        <asm.version>9.4</asm.version>
+        <asm.version>9.7.1</asm.version>
         <assertj.version>3.16.1</assertj.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.scm.id>github</project.scm.id>

--- a/src/Compiler/Jvm/InferredType.idr
+++ b/src/Compiler/Jvm/InferredType.idr
@@ -71,7 +71,7 @@ mutual
   export
   Show InferredFunctionType where
     show (MkInferredFunctionType returnType argumentTypes) =
-      assert_total $ showSep "⟶" (show <$> (argumentTypes ++ [returnType]))
+      assert_total $ showSep " -> " (show <$> (argumentTypes ++ [returnType]))
 
   export
   Show JavaLambdaType where

--- a/src/Compiler/Jvm/Jname.idr
+++ b/src/Compiler/Jvm/Jname.idr
@@ -39,15 +39,15 @@ getSimpleName : Jname -> String
 getSimpleName = getSimpleNameWithSep "/"
 
 export
-implementation Eq Jname where
+Eq Jname where
     name1 == name2 = getSimpleName name1 == getSimpleName name2
 
 export
-implementation Ord Jname where
+Ord Jname where
   compare name1 name2 = compare (getSimpleName name1) (getSimpleName name2)
 
 export
-implementation Show Jname where
+Show Jname where
     show = getSimpleName
 
 export

--- a/src/Compiler/Jvm/Variable.idr
+++ b/src/Compiler/Jvm/Variable.idr
@@ -131,12 +131,14 @@ asmCast IChar IChar     = pure ()
 asmCast IShort IShort   = pure ()
 asmCast IInt IBool      = pure ()
 asmCast IInt IInt       = pure ()
+asmCast IChar IInt      = pure ()
 asmCast ILong ILong     = pure ()
 asmCast IFloat IFloat   = pure ()
 asmCast IDouble IDouble = pure ()
 asmCast (IArray _) (IArray _) = pure ()
 
 asmCast IBool IInt = boolToInt
+asmCast IVoid IInt = iconst 0 -- for primitive functions returning void, Idris return type will be int
 asmCast IInt IChar = i2c
 asmCast IInt IByte = i2b
 asmCast IInt IShort = i2s
@@ -183,7 +185,6 @@ asmCast (IRef _ _ _) arr@(IArray _) = checkcast $ getJvmTypeDescriptor arr
 asmCast (IArray _) (IRef clazz _ _) = checkcast clazz
 
 asmCast _ IVoid = pure ()
-asmCast IVoid IVoid = pure ()
 asmCast IVoid (IRef _ _ _) = aconstnull
 asmCast IVoid IUnknown = aconstnull
 asmCast ty IUnknown = pure ()
@@ -295,6 +296,9 @@ loadVar sourceLocTys ty IInt var = loadAndUnboxInt ty sourceLocTys var
 loadVar sourceLocTys ty ILong var =
     let loadInstr = \index => do aload index; objToLong
     in opWithWordSize sourceLocTys loadInstr var
+
+loadVar sourceLocTys (IRef "java/math/BigInteger" _ _) (IRef "java/math/BigInteger" _ _) var =
+  opWithWordSize sourceLocTys aload var
 
 loadVar sourceLocTys _ (IRef "java/math/BigInteger" _ _) var =
     let loadInstr = \index => do

--- a/tests/jvm/nat2fin/Check.idr
+++ b/tests/jvm/nat2fin/Check.idr
@@ -15,7 +15,7 @@ isOptimized (_ :: _ :: []) = False
 isOptimized (_ :: []) = False
 isOptimized (line1 :: line2 :: line3 :: rest) = (("String 375" `isSuffixOf` line1) &&
   ("Method java/math/BigInteger.\"<init>\":(Ljava/lang/String;)V" `isSuffixOf` line2) &&
-  ("Method M_Data/Fin.show$show_Show_$lparFin$s$n$rpar:(Ljava/lang/Object;)Ljava/lang/Object;" `isSuffixOf` line3)) ||
+  ("Method M_Data/Fin.show$show_Show_$lparFin$s$n$rpar:" `isInfixOf` line3)) ||
   isOptimized (line2 :: line3 :: rest)
 
 main : IO ()


### PR DESCRIPTION
* Use Idris function types to reduce boxing in JVM bytecode
