### PR TITLE
Add module prefix

### DIFF
--- a/idris-jvm-assembler/src/main/java/io/github/mmhelloworld/idrisjvm/assembler/IdrisName.java
+++ b/idris-jvm-assembler/src/main/java/io/github/mmhelloworld/idrisjvm/assembler/IdrisName.java
@@ -1,106 +1,138 @@
 package io.github.mmhelloworld.idrisjvm.assembler;
 
 import io.github.mmhelloworld.idrisjvm.runtime.IdrisList;
+import io.github.mmhelloworld.idrisjvm.runtime.IdrisList.Cons;
+import io.github.mmhelloworld.idrisjvm.runtime.IdrisList.Nil;
 
-import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Map.Entry;
-
-import static java.lang.Character.toUpperCase;
-import static java.util.Arrays.asList;
 
 public final class IdrisName {
 
-    private static final Map<Character, String> REPLACEMENTS = new HashMap<>();
+  private static final Map<Character, String> REPLACEMENTS = new HashMap<>();
+  private static final Map<String, String> NORMALIZED_NAMES_CACHE = new HashMap<>();
 
-    private IdrisName() {
+  static {
+    REPLACEMENTS.put(' ', "$s");
+    REPLACEMENTS.put('!', "$not");
+    REPLACEMENTS.put('"', "$d");
+    REPLACEMENTS.put('#', "$hash");
+    REPLACEMENTS.put('%', "$mod");
+    REPLACEMENTS.put('&', "$and");
+    REPLACEMENTS.put('\'', "$q");
+    REPLACEMENTS.put('(', "$lpar");
+    REPLACEMENTS.put(')', "$rpar");
+    REPLACEMENTS.put('*', "$mul");
+    REPLACEMENTS.put('+', "$add");
+    REPLACEMENTS.put(',', "$com");
+    REPLACEMENTS.put('-', "$hyp");
+    REPLACEMENTS.put('.', "$dot");
+    REPLACEMENTS.put('/', "$div");
+    REPLACEMENTS.put('\\', "$bsl");
+    REPLACEMENTS.put(':', "$col");
+    REPLACEMENTS.put(';', "$scol");
+    REPLACEMENTS.put('<', "$lt");
+    REPLACEMENTS.put('=', "$eq");
+    REPLACEMENTS.put('>', "$gt");
+    REPLACEMENTS.put('?', "$ques");
+    REPLACEMENTS.put('@', "$at");
+    REPLACEMENTS.put('^', "$caret");
+    REPLACEMENTS.put('`', "$grave");
+    REPLACEMENTS.put('{', "$lbr");
+    REPLACEMENTS.put('|', "$or");
+    REPLACEMENTS.put('}', "$rbr");
+    REPLACEMENTS.put('~', "$tilde");
+    REPLACEMENTS.put('[', "$lsqr");
+    REPLACEMENTS.put(']', "$rsqr");
+  }
+  private IdrisName() {
+  }
+
+  /**
+   * Transforms a constructor name into a class name.
+   * Rules:
+   * - If the constructor name has no "/" separator, use programName + "/" + constructorName
+   * - If it has separators, prefix all segments except the last with "M_"
+   * - The last segment remains without "M_" prefix
+   */
+  public static String getIdrisConstructorClassName(String programName, String idrisConstructorName) {
+    if (!idrisConstructorName.contains("/")) {
+      // No path separator, use programName prefix
+      return programName + "/" + idrisConstructorName;
     }
 
-    static {
-        REPLACEMENTS.put(' ', "$s");
-        REPLACEMENTS.put('!', "$not");
-        REPLACEMENTS.put('"', "$d");
-        REPLACEMENTS.put('#', "$hash");
-        REPLACEMENTS.put('%', "$mod");
-        REPLACEMENTS.put('&', "$and");
-        REPLACEMENTS.put('\'', "$q");
-        REPLACEMENTS.put('(', "$lpar");
-        REPLACEMENTS.put(')', "$rpar");
-        REPLACEMENTS.put('*', "$mul");
-        REPLACEMENTS.put('+', "$add");
-        REPLACEMENTS.put(',', "$com");
-        REPLACEMENTS.put('-', "$hyp");
-        REPLACEMENTS.put('.', "$dot");
-        REPLACEMENTS.put('/', "$div");
-        REPLACEMENTS.put('\\', "$bsl");
-        REPLACEMENTS.put(':', "$col");
-        REPLACEMENTS.put(';', "$scol");
-        REPLACEMENTS.put('<', "$lt");
-        REPLACEMENTS.put('=', "$eq");
-        REPLACEMENTS.put('>', "$gt");
-        REPLACEMENTS.put('?', "$ques");
-        REPLACEMENTS.put('@', "$at");
-        REPLACEMENTS.put('^', "$caret");
-        REPLACEMENTS.put('`', "$grave");
-        REPLACEMENTS.put('{', "$lbr");
-        REPLACEMENTS.put('|', "$or");
-        REPLACEMENTS.put('}', "$rbr");
-        REPLACEMENTS.put('~', "$tilde");
-        REPLACEMENTS.put('[', "$lsqr");
-        REPLACEMENTS.put(']', "$rsqr");
+    // Split by "/" and prefix all but the last segment with "M_"
+    String[] segments = idrisConstructorName.split("/");
+    StringBuilder builder = new StringBuilder();
+
+    for (int index = 0; index < segments.length; index++) {
+      if (index > 0) {
+        builder.append("/");
+      }
+      if (index < segments.length - 1) {
+        // All segments except the last get "M_" prefix
+        builder.append("M_").append(segments[index]);
+      } else {
+        // Last segment has no prefix
+        builder.append(segments[index]);
+      }
     }
 
-    public static IdrisList getIdrisFunctionName(String programName, String idrisNamespace, String idrisFunctionName) {
-        return getIdrisName(getRootModuleName(programName), idrisNamespace, idrisFunctionName);
-    }
+    return builder.toString();
+  }
 
-    public static String getIdrisConstructorClassName(String programName, String idrisName) {
-        return addModulePrefix(getRootModuleName(programName), idrisName);
+  /**
+   * Transforms a module name and function name into an IdrisList containing
+   * the transformed class name and function name.<br>
+   * <b>Rules:</b><br>
+   * - If moduleName has no "/" (single segment), use programName + "/" + moduleName <br>
+   * - If moduleName has "/", split by "/" and prefix each segment with "M_", joining with "/" <br>
+   * - Return an IdrisList with [transformedModuleName, functionName]
+   */
+  public static IdrisList getIdrisFunctionName(String programName, String idrisNamespace, String idrisFunctionName) {
+    String className;
+    if (idrisNamespace.startsWith("io/github/mmhelloworld/idrisjvm")) {
+      className = idrisNamespace;
+    } else if (idrisNamespace.startsWith("nomangle:")) {
+      className = idrisNamespace.substring("nomangle:".length());
+    } else {
+      className = getIdrisFunctionClassName(programName, idrisNamespace);
     }
+    return new Cons(className, new Cons(idrisFunctionName, Nil.INSTANCE));
+  }
 
-    public static String transformCharacters(String value) {
-        StringBuilder builder = new StringBuilder();
-        for (char c: value.toCharArray()) {
-            builder.append(transformCharacter(c));
+  private static String getIdrisFunctionClassName(String programName, String moduleName) {
+    if (!moduleName.contains("/")) {
+      // Single segment module gets programName + "/" prefix
+      return programName + "/" + moduleName;
+    } else {
+      // Split by "/" and prefix each segment with "M_"
+      String[] segments = moduleName.split("/");
+      StringBuilder builder = new StringBuilder();
+      for (int index = 0; index < segments.length; index++) {
+        if (index > 0) {
+          builder.append("/");
         }
-        return builder.toString();
+        builder.append("M_").append(segments[index]);
+      }
+      return builder.toString();
     }
+  }
 
-    private static String transformCharacter(char c) {
-        return REPLACEMENTS.getOrDefault(c, String.valueOf(c));
-    }
+  public static String transformCharacters(String value) {
+    return NORMALIZED_NAMES_CACHE.computeIfAbsent(value, IdrisName::transformCharactersNoCache);
+  }
 
-    private static IdrisList getIdrisName(String programName, String idrisNamespace, String memberName) {
-        Entry<String, String> classAndMemberName = getClassAndMemberName(programName, idrisNamespace, memberName);
-        return IdrisList.fromIterable(asList(classAndMemberName.getKey(), classAndMemberName.getValue()));
+  private static String transformCharactersNoCache(String value) {
+    StringBuilder builder = new StringBuilder();
+    for (char c : value.toCharArray()) {
+      builder.append(transformCharacter(c));
     }
+    return builder.toString();
+  }
 
-    private static String getRootModuleName(String programName) {
-        return toUpperCase(programName.charAt(0)) + programName.substring(1);
-    }
+  private static String transformCharacter(char c) {
+    return REPLACEMENTS.getOrDefault(c, String.valueOf(c));
+  }
 
-    private static Entry<String, String> getClassAndMemberName(String programName, String idrisNamespace,
-                                                               String memberName) {
-        String className = getClassName(programName, idrisNamespace);
-        return new SimpleImmutableEntry<>(className, memberName);
-    }
-
-    private static String getClassName(String programName, String idrisNamespace) {
-        if (idrisNamespace.startsWith("io/github/mmhelloworld/idrisjvm")) {
-            return idrisNamespace;
-        } else if (idrisNamespace.startsWith("nomangle:")) {
-            return idrisNamespace.substring("nomangle:".length());
-        } else {
-            return addModulePrefix(programName, idrisNamespace);
-        }
-    }
-
-    private static String addModulePrefix(String programName, String name) {
-        if (name.indexOf('/') < 0) {
-            return programName + "/" + name;
-        } else {
-            return name;
-        }
-    }
 }

--- a/idris-jvm-assembler/src/test/java/io/github/mmhelloworld/idrisjvm/jvmassembler/IdrisNameTest.java
+++ b/idris-jvm-assembler/src/test/java/io/github/mmhelloworld/idrisjvm/jvmassembler/IdrisNameTest.java
@@ -15,19 +15,19 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 public final class IdrisNameTest {
 
     static Stream<Arguments> getIdrisFunctionName() {
-        return Stream.of(
-            arguments("Data/List", "take", IdrisList.fromIterable(asList("Data/List", "take"))),
-            arguments("Main", "bar", IdrisList.fromIterable(asList("Main/Main", "bar"))),
-            arguments("Foo", "bar", IdrisList.fromIterable(asList("Main/Foo", "bar"))),
-            arguments("Main/Foo", "bar", IdrisList.fromIterable(asList("Main/Foo", "bar"))),
-            arguments("Main/Foo/Bar/Baz", "bar", IdrisList.fromIterable(asList("Main/Foo/Bar/Baz", "bar"))));
+      return Stream.of(
+        arguments("Core/Name/Namespace/ModuleIdent", "toPath", IdrisList.fromIterable(asList(
+          "M_Core/M_Name/M_Namespace/M_ModuleIdent", "toPath"))),
+        arguments("Foo", "bar", IdrisList.fromIterable(asList("main/Foo", "bar"))),
+        arguments("Main/Foo", "bar", IdrisList.fromIterable(asList("M_Main/M_Foo", "bar"))),
+        arguments("Main/Foo/Bar/Baz", "bar", IdrisList.fromIterable(asList("M_Main/M_Foo/M_Bar/M_Baz", "bar"))));
     }
 
     static Stream<Arguments> getConstructorClassName() {
-        return Stream.of(
-            arguments("Data/List/Take", "Data/List/Take"),
-            arguments("Prelude/Foo", "Prelude/Foo"),
-            arguments("Prelude", "Main/Prelude"));
+      return Stream.of(
+        arguments("Core/Name/Namespace/ModuleIdent", "M_Core/M_Name/M_Namespace/ModuleIdent"),
+        arguments("Prelude/Foo", "M_Prelude/Foo"),
+        arguments("Prelude", "main/Prelude"));
     }
 
     @ParameterizedTest

--- a/src/Compiler/Jvm/Codegen.idr
+++ b/src/Compiler/Jvm/Codegen.idr
@@ -1970,17 +1970,18 @@ assembleDefinition idrisName fc = do
             withScope $ assembleExpr False delayedType optimizedExpr
             field PutStatic declaringClassName methodName "Lio/github/mmhelloworld/idrisjvm/runtime/MemoizedDelayed;"
 
-createMainMethod : {auto stateRef: Ref AsmState AsmState} -> String -> Jname -> Core ()
-createMainMethod programName mainFunctionName = do
+createMainMethod : {auto stateRef: Ref AsmState AsmState} -> String -> Jname -> String -> Core ()
+createMainMethod programName mainFunctionName javaMainClassName = do
     function <- getFunction mainFunctionName
-    let idrisMainClassMethodName = jvmClassMethodName function
-    let mainClassName = className idrisMainClassMethodName
-    createMethod [Public, Static] "Main.idr" mainClassName "main" "([Ljava/lang/String;)V" Nothing Nothing [] []
+    logAsm ("generating main function in " ++ javaMainClassName)
+    createMethod [Public, Static] "Main.idr" javaMainClassName "main" "([Ljava/lang/String;)V" Nothing Nothing [] []
     methodCodeStart
     ldc $ StringConst programName
     aload 0
     invokeMethod InvokeStatic runtimeClass "setProgramArgs" "(Ljava/lang/String;[Ljava/lang/String;)V" False
-    field GetStatic mainClassName (methodName idrisMainClassMethodName) "Lio/github/mmhelloworld/idrisjvm/runtime/MemoizedDelayed;"
+    let idrisMainClassMethodName = jvmClassMethodName function
+    let idrisMainClassName = className idrisMainClassMethodName
+    field GetStatic idrisMainClassName (methodName idrisMainClassMethodName) "Lio/github/mmhelloworld/idrisjvm/runtime/MemoizedDelayed;"
     invokeMethod InvokeVirtual "io/github/mmhelloworld/idrisjvm/runtime/MemoizedDelayed" "evaluate"
         "()Ljava/lang/Object;" False
     return
@@ -2482,8 +2483,9 @@ compileToJvmBytecode outputDirectory outputFile term = do
         exportDefs globalState $ mapMaybe (getExport noMangleMap . fst) allDefs
         mainAsmState <- createAsmState globalState mainFunctionName
         let mainFunctionJname = jvmName mainFunctionName
-        ignore $ runAsm mainAsmState $ \stateRef => createMainMethod programName mainFunctionJname
-        classCodeEnd globalState outputDirectory outputFile (className mainFunctionJname)
+        let javaMainClassName = programName ++ "/JvmMain"
+        ignore $ runAsm mainAsmState $ \stateRef => createMainMethod programName mainFunctionJname javaMainClassName
+        classCodeEnd globalState outputDirectory outputFile (programName ++ ".JvmMain")
   where
     inferFunctionTypes : AsmGlobalState -> LazyList (Name, FC, NamedDef)
                        -> Core (LazyList (Name, FC, Ref AsmState AsmState))

--- a/src/Compiler/Jvm/Jname.idr
+++ b/src/Compiler/Jvm/Jname.idr
@@ -63,11 +63,7 @@ jvmIdrisMainMethodName = "jvm$idrisMain"
 
 export
 idrisMainFunctionName : String -> Name
-idrisMainFunctionName rootPackage =
-  let mainClass = case strUncons rootPackage of
-                    Just (firstChar, rest) => strCons (toUpper firstChar) rest ++ ".Main"
-                    Nothing => "Main"
-  in NS (mkNamespace mainClass) (UN $ Basic jvmIdrisMainMethodName)
+idrisMainFunctionName rootPackage = NS (mkNamespace $ rootPackage ++ ".Main") (UN $ Basic jvmIdrisMainMethodName)
 
 export
 className : Jname -> String

--- a/tests/jvm/jvm035/expected
+++ b/tests/jvm/jvm035/expected
@@ -1,3 +1,3 @@
 1/1: Building Mod1 (Mod1.idr)
 hello world
-build/exec/test_app/Test/Main.class
+build/exec/test_app/test/Main.class

--- a/tests/jvm/jvm035/run
+++ b/tests/jvm/jvm035/run
@@ -5,6 +5,6 @@ export IDRIS2_INC_CGS=jvm
 $1 --no-banner --no-color --console-width 0 -o test Mod2.idr < input
 ./build/exec/test${IDRIS_EXEC_EXT}
 
-ls build/exec/test_app/Test/Main.class
+ls build/exec/test_app/test/Main.class
 
 rm -rf build

--- a/tests/jvm/nat2fin/Check.idr
+++ b/tests/jvm/nat2fin/Check.idr
@@ -15,7 +15,7 @@ isOptimized (_ :: _ :: []) = False
 isOptimized (_ :: []) = False
 isOptimized (line1 :: line2 :: line3 :: rest) = (("String 375" `isSuffixOf` line1) &&
   ("Method java/math/BigInteger.\"<init>\":(Ljava/lang/String;)V" `isSuffixOf` line2) &&
-  ("Method Data/Fin.show$show_Show_$lparFin$s$n$rpar:" `isInfixOf` line3)) ||
+  ("Method M_Data/M_Fin.show$show_Show_$lparFin$s$n$rpar:" `isInfixOf` line3)) ||
   isOptimized (line2 :: line3 :: rest)
 
 main : IO ()

--- a/tests/jvm/nat2fin/run
+++ b/tests/jvm/nat2fin/run
@@ -2,7 +2,7 @@ rm -rf build
 
 $1 --no-banner --no-color --quiet -o test Test.idr
 
-javap -c -cp build/exec/test_app Test.Main > build/exec/test_app/test-decompiled.txt
+javap -c -cp build/exec/test_app test.Main > build/exec/test_app/test-decompiled.txt
 
 $1 --no-banner --no-color --console-width 0 Check.idr < input
 


### PR DESCRIPTION
# Description
Add a prefix to module names as sometimes there could be a type and namespace with same name like `ModuleIdent` in `Core.Name.Namespace`. As Idris constructors and namespaces are compiled to Java classes in the bytecode, this creates a conflict. Fix is to prefix module names including namespaces in a module with `M_`.
