### PR TITLE
Monomorphization: Refine family-typed return, eliminate dead code

### DIFF
--- a/docs/monomorphization-design.md
+++ b/docs/monomorphization-design.md
@@ -346,6 +346,9 @@ v2 (§13) lifts this: a typed callback interface is generated and the HOF gets a
 | Higher-order specialisation (v2, §13) | ✅ done (decl-driven + polymorphic, arity 1 **and 2**) | `Asm.idr`, `Optimizer.idr`, `Codegen.idr`, `Assembler.java` |
 | FC-collision miscompile fix (§7)     | ✅ done     | `src/Compiler/Jvm/Optimizer.idr`                   |
 | Family-typed return refinement (§14) | ✅ done     | `Codegen.idr` (`refineNaturalReturn`), `Optimizer.idr` (`getResultTypeCon`) |
+| Spec-return propagation (parametric, §14.1) | ✅ done | `Codegen.idr` (`computeReturnRefinement`/`setSpecReturn`), `Optimizer.idr` (`inferExprApp`) |
+| Liveness-aware `naturalConsLive` (§14.2) | ✅ done (reachability closure) | `Codegen.idr` (`computeNaturalConsLive`/`reachableFns`) |
+| Dead-function elimination (§14.3)    | ✅ done     | `Codegen.idr` (`assembleNameFcStateRefs` filters by `liveFns`) |
 | Reference-type narrowing (e.g. `String`) | ❌ planned | —                                                |
 | Benchmarks vs main (JMH)             | ✅ done (`benchmark/jmh`, §13.2) | `benchmark/jmh/`                       |
 
@@ -650,8 +653,9 @@ remaining boxing site for user data types.
 When a natural producer's declared result is a single TCon `T` and every
 data-carrying construction in its body belongs to **one** family
 instantiation of `T`, the function's return type is refined from `Object`
-to that family interface (`Box$F`, `Tree$F`) — or, for a RECORD/UNIT
-producer, the lone DCon spec class.  The refined type:
+to that family interface (`Box$F`, `Tree$F`).  Only a **family interface**
+is a valid target — never a record's concrete DCon spec class (see the
+soundness gates below).  The refined type:
 
 - persists on the per-name `AsmState` (`getCurrentFunction`), so it is read
   back by the next plan pass, by the `naturalConsLive` fixpoint, and by
@@ -683,7 +687,31 @@ interface at `areturn` by the existing `asmCast`/`loadVar` return path and
 succeeds at runtime.  The body's construction sites (`conSiteLog`) only
 choose **which** instantiation; the type gate guarantees soundness.
 
-Conservative refusals: synthetic shapes (CONS/JUST/...) are skipped — their
+**The result TCon must be non-parametric and non-indexed**
+(`getTypeConArity == 0`).  A parametric TCon has more than one runtime
+instantiation, and the natural function's refined return is **inherited by
+its specs** via the call-site log (`mkSpecSig`) — but an `int`-spec of a
+`WithBounds ty` producer builds `MkBounded$I$I$L` while the natural refined
+to `MkBounded$L$I$L`, so the spec's `areturn` fails verification (`Bad
+return type`).  A zero-arity TCon has exactly one instantiation, so the
+natural function, every inheriting spec, and every caller agree on the
+single family/spec class.  (Found self-hosting the compiler's own
+`Libraries.Text.Bounded`; non-parametric `Box`/`Tree` never exposed it.)
+
+**Records (RECORD/UNIT) are never refined.**  A family interface is a
+*marker* every member implements (`computeNaturalToTConIfaces`), so a
+`checkcast` to it always succeeds; a record has no such interface, only its
+concrete DCon spec class, whose identity is **per-construction-site
+field-type inference** — the same record is `MkPFR$L$L$I` where an `Int`
+field was inferred primitive and natural `MkPFR` where it was `Object`.
+Refining a producer's return to one of those classes commits consumers to
+it while a differently-inferred sibling value flows in →
+`ClassCastException` (found self-hosting `Idris.Package.partitionOpts` —
+the same failure mode as the §7 FC-collision miscompile).  Records have
+`tconClassName == ""`, so the family-interface-only rule excludes them
+automatically.
+
+Other conservative refusals: synthetic shapes (CONS/JUST/...) are skipped — their
 natural class is essentially always live program-wide (boxed prelude
 lists), so the family-interface typed read is blocked by `naturalConsLive`
 anyway (this is the §12 "recursive slots for synthetic shapes" limitation);
@@ -703,13 +731,142 @@ recursive slot cast-free; only the nullary `Leaf` branches pay the single
 `Box`/`mkBox`/`useBox` chain) and the updated `tests/jvm/conrecursiveslots`
 (`build` now returns `Tree$F`).
 
+### 14.1 Spec-return propagation (parametric producers)
+
+The natural-return refinement above is **monomorphic only** (the
+non-parametric gate): a polymorphic producer like `mkTree : a -> Tree a` has
+a type-erased natural method that serves every instantiation, so its return
+stays Object.  But its **spec** `mkTree$sp0(int)` genuinely returns `Tree
+Int`, so its return may carry the concrete family interface `Tree$F$I`.
+
+Each spec's return is refined independently in `step`'s per-spec loop
+(`computeReturnRefinement … requireMonomorphic=False`) and written back into
+the plan entry (`setSpecReturn`).  Because each spec gets its OWN correct
+return — keyed to its instantiation — there is no inherited-mismatch hazard
+(the WithBounds VerifyError of §14): a spec never inherits another
+instantiation's class.
+
+`computeReturnRefinement` has **two sources**, in order:
+
+1. **The body's inferred return type** — `inferDef` now stores its
+   `inferExpr` result on the `AsmState` (`inferredReturnType`) instead of
+   discarding it.  When that type is a (non-synthetic) family interface, the
+   body provably produces it, so the return is refined to it directly (no
+   gate — a polymorphic body infers Object, not a concrete family).  Because
+   that body type already reflects the plan (a call `g x` infers as
+   `g$sp0`'s refined return via `inferExprApp`), this covers **pass-through
+   producers** (`f x = g x`, whose body is just a spec call), direct
+   constructions, and uniform-branch cases.
+2. **Construction sites** (`conSiteLog`) — the fallback for **recursive**
+   producers, whose `Leaf`-base branch makes `combineSwitchTypes` collapse
+   the body type to `Object` even though the data-carrying constructions are
+   one family.  This path keeps the non-parametric result-TCon gate (it has
+   no per-value body type to vouch for soundness).
+
+A refined spec return reaches callers through **`inferExprApp`**: when a
+call's inferred argument types match a spec of the callee (the same
+parameter-type match `rewriteSpecCalls` uses), inference takes the call's
+type from that spec's refined return rather than the natural Object return.
+So `sumTree (mkTree 7)` — whose argument is a *call*, not a construction —
+logs `Tree$F$I` for `sumTree`'s slot and earns `sumTree$sp0(Tree$F$I)`.
+Inference and emission agree: emission lowers the already-rewritten
+`mkTree$sp0` head and reads the same refined type via `findFunctionType`.  A
+spec-return change re-dirties the callee's callers (surfaced through
+`specKeys`, which also ungates `nextDirty`'s type-ripple propagation);
+monotone (Object→family once per spec), so the fixpoint converges.
+
+### 14.2 Liveness-aware `naturalConsLive`
+
+Spec-return propagation alone earns the consumer a family-typed parameter,
+but the typed-accessor *read* was still blocked: the typed read fires only
+when the constructor's natural class is dead (`naturalConsLive`), and the
+**polymorphic natural producer is always emitted** and builds the natural
+`Node` (`x : Object`), keeping it live.  Yet that natural method is *never
+called* — every caller (`mkTree 7`) is rewritten to `mkTree$sp0` — so its
+construction never executes at runtime.
+
+`computeNaturalConsLive` is therefore made **liveness-aware**: each
+construction site is tagged with the function it was observed in, the
+fixpoint maintains a **persistent per-node graph** (`sitesByFn`/`refsByFn`,
+keyed by natural names AND spec names — draining stays worklist-incremental,
+but the maps accumulate the full rewritten graph), and a site counts toward
+natural-liveness only when its origin function is **live**.  Liveness is a
+proper **reachability closure** (`reachableFns`) from the roots
+(`main`/exports) over the full `refsByFn` — a function is live only when
+reachable through references in OTHER live bodies, so a natural referenced
+SOLELY from dead code is correctly dead (not merely "referenced somewhere").
+The dead natural `mkTree`'s `Node` site drops out, so `Node` is not
+natural-live and `sumTree$sp0` reads `getInt0`/`getRef` and its recursion
+stays in the spec (the typed `getRef` returns `Tree$F$I`, cast-free).
+
+This is computed **incrementally** — `naturalConsLive` is the codegen
+hotspot, so the loop must never do per-round full-graph work.  `liveFns`
+grows via `growReachable` (seeded each round with only the dirty live
+functions, since reachability can only grow and only from a re-drained live
+body), and each round contributes `needsNatural` for the sites of only the
+**touched** nodes — re-drained dirty nodes that are live, plus newly-live
+nodes — unioned and never removed.  Because `needsNatural` is pure in the
+fixed `conPlan` (a site's verdict never changes) and reachability only
+grows, this is equivalent at convergence to rescanning the whole graph every
+round, but avoids the quadratic that made an earlier cut ~2× slower.
+Reachability never changes a function's own inference, so the worklist's
+existing re-dirty triggers (a constructor became live, or a callee's type
+changed) keep the persistent state valid with no extra liveness
+re-dirtying.
+
+Soundness rests on the existing **union-from-∅** structure (which already
+handles the slot-flipping non-monotonicity — turning a typed read on can
+flip a slot and change a sibling's spec match): the union accumulates each
+pass's live-function contributions, including the converged final pass whose
+rewriting emission uses, so a typed read implies no LIVE function builds the
+natural class under that rewriting.  Things that keep a natural live —
+exports, a call at a type matching no spec, a first-class `NmRef` (eta /
+partial application / passed to a HOF) — surface as references reachable from
+roots.  It only affects polymorphic producers: a monomorphic producer is
+called directly, hence live, so non-parametric results (§14) and all existing
+tests are unchanged.
+
+Covered by `tests/jvm/conreturnfamilypoly` (`mkTree`/`sumTree` over `Tree a`:
+`mkTree$sp0 → Tree$F$I`, `sumTree$sp0(Tree$F$I)` with typed reads, spec-stable
+recursion, no natural `Node`) and `tests/jvm/conreturnfamilyreach` (the
+second-order case: a dead natural `viaOuter` is the only referrer of natural
+`leafOf`, so reachability — unlike "referenced anywhere" — still marks
+`leafOf` dead and the consumer reads typed).
+
+### 14.3 Dead-function elimination
+
+The reachability closure (`reachableFns`, §14.2) is exactly the set of
+functions callable in the rewritten graph, so emission uses it to **drop
+dead functions**.  `computeNaturalConsLive` returns the live-function set
+alongside `natLive`, and `assembleNameFcStateRefs` emits a natural method or
+a spec only when its name is in that set.  A polymorphic producer whose every
+caller was rewritten to a spec (`mkTree`), a HOF natural whose callers all
+use the typed spec (`applyN`), and the natural constructor classes that only
+those dead bodies build (natural `Node`) are no longer emitted — pure dead
+bytecode that the JVM never loaded but that bloated the class files.
+
+This refines §7's invariant: the natural method is still **never replaced by
+a trampoline**, and it is **retained whenever a live caller invokes it**
+(unspecialised, polymorphic, or external) — it is dropped only when no live
+body references it.  `liveFns` is a superset of genuinely-callable functions
+(every call head and first-class `NmRef` is followed from `main`/exports), so
+DCE never removes a method that is actually used; the self-host (which keeps
+every reachable compiler function) and the runtime of all jvm tests confirm
+no `NoSuchMethodError`.  Covered by the structural assertions in
+`tests/jvm/hofspecialisation` (natural `applyN` eliminated),
+`conreturnfamilypoly` (natural `mkTree`/`sumTree`/`Node` gone), and
+`conreturnfamily` (parametric-record natural dropped, live spec retained).
+
 ### Scope and deferred work
 
-Natural producers only — a **spec's** refined return does not reach its
-callers (callers infer against the natural callee; `rewriteSpecCalls` only
-renames the head afterward), so cross-spec-chain propagation is out of
-scope.  Synthetic-shape lists still read boxed (needs the CONS/RCONS
-split-by-recursion of §12).
+Synthetic-shape lists still read boxed (needs the CONS/RCONS
+split-by-recursion of §12).  Return refinement now derives from the body's
+inferred type as well as construction sites (§14.1), so pass-through
+producers (`f x = g x`) propagate; the one remaining gap is a **recursive**
+producer of a **parametric** instantiation (`f : Int -> Tree Int` with a
+`Leaf`-base recursion), where the body type collapses to `Object` (so source
+1 misses it) and the construction-site fallback's non-parametric gate
+rejects it — niche enough to leave as future work.
 
 ## 15. Future work (v3 and beyond)
 

--- a/docs/monomorphization-design.md
+++ b/docs/monomorphization-design.md
@@ -343,9 +343,11 @@ v2 (§13) lifts this: a typed callback interface is generated and the HOF gets a
 | `assembleSpec` per-spec emission     | ✅ done     | `src/Compiler/Jvm/Codegen.idr`                     |
 | Call-forest reachability             | ✅ done     | `src/Compiler/Jvm/FunctionTree.idr`, `Codegen.idr` |
 | Test (`tests/jvm/specialisation`)    | ✅ done     | `tests/jvm/specialisation/`                        |
-| Higher-order specialisation (v2, §13) | ✅ done (decl-driven + polymorphic, arity 1) | `Asm.idr`, `Optimizer.idr`, `Codegen.idr`, `Assembler.java` |
+| Higher-order specialisation (v2, §13) | ✅ done (decl-driven + polymorphic, arity 1 **and 2**) | `Asm.idr`, `Optimizer.idr`, `Codegen.idr`, `Assembler.java` |
+| FC-collision miscompile fix (§7)     | ✅ done     | `src/Compiler/Jvm/Optimizer.idr`                   |
+| Family-typed return refinement (§14) | ✅ done     | `Codegen.idr` (`refineNaturalReturn`), `Optimizer.idr` (`getResultTypeCon`) |
 | Reference-type narrowing (e.g. `String`) | ❌ planned | —                                                |
-| Benchmarks vs main                   | ❌ planned  | —                                                  |
+| Benchmarks vs main (JMH)             | ✅ done (`benchmark/jmh`, §13.2) | `benchmark/jmh/`                       |
 
 ---
 
@@ -364,6 +366,10 @@ v2 (§13) lifts this: a typed callback interface is generated and the HOF gets a
 - **Plan is updated mid-pass.** `step` writes back into `plan` and the same iteration's later names use the updated plan. The outer `iterate'` continues until `scan` reports no change.
 
 - **AsmState reuse.** The original function's `AsmState` is the same one created up-front in `inferFunctionTypes`. `buildSpecialisationPlan` and the final `assembleNameFcStateRefs` both call `setSpecialisationPlan` on it before re-running inference / assembly, so the latest plan is always visible.
+
+- **Site logs must be keyed by a *unique* FC, not the raw frontend FC** (`uniquifySiteFcs`). Both `conSiteLog` and `callSiteLog` associate inferred argument types to a site by `FC`, but frontend inlining duplicates *definition-site* FCs — every inlined `pure x` carries the FC of the `Right x` inside `pure`'s own definition. Without uniquification, `assembleCon` / `rewriteSpecCalls` resolve a site against an entry logged by an *unrelated* sibling call that happened to share the FC, and emit the wrong spec class. The self-hosted compiler miscompiled `pure $ partitionOpts opts` as the `Right$I` (int-slot) spec — `Conversion.toInt` on a `MkPFR` record → `NumberFormatException` while installing the prelude. **Fix:** `markUniqueFc` / `uniquifySiteFcs` / `uniquifyDefSiteFcs` (Optimizer.idr), run at the *end* of `optimize`, stamp a per-definition counter into the **start column** of every `NmCon`/`NmApp` FC. Start columns are ignored by `getLineNumbers`, so debug line info is preserved; `EmptyFC` becomes `MkVirtualFC (Virtual Interactive) (0, counter) (0, 0)`. Applied-lambda sentinel FCs (`appliedLambdaSwitchIndicator` / `appliedLambdaLetIndicator`) are left untouched — they are matched by FC equality in `getAppliedLambdaType`. `rewriteSpecCalls.lookupSiteType` additionally filters by callee `Name` (FC alone is insufficient even after uniquification). If wrong-spec crashes (`toInt`/`ClassCast` on constructor values) recur, check FC-keyed lookups first.
+
+- **`IUnknown` must normalise to `Object` at `callSiteLog` time** (in `inferExprApp`). Spec bodies' interior recursive calls log `IUnknown` for con-case binder arguments. `rewriteSpecCalls` matches a site against a spec by *exact* parameter-type equality, and `IUnknown` ≠ the spec's `Object` slot — so the spec recursed back into the **natural** variant after the first element (bytecode even `checkcast`s the typed `Fn$…` interface down to `Function`). Normalising `IUnknown → Object` when the entry is logged closes a pre-existing gap that affected **all** non-tail-recursive specs, not just arity-2 callbacks.
 
 ---
 
@@ -552,7 +558,7 @@ A higher-order parameter is `java.util.function.Function` with a boxed `apply(Ob
 
 ### Typed callback interfaces (`Fn$I$I`)
 
-One generated JVM interface per distinct typed callback signature, named parameter-chars-then-return-char with the `specConDescriptorChar` letters (`L` = exactly `java/lang/Object`): `int apply(int)` → `<programName>/Fn$I$I`. The name is injective over the signature, so **the name is the registry**: `parseCallbackIfaceType` (Asm.idr) decodes any `IRef …/Fn$…` back to its `InferredFunctionType`, and no plan-threading is needed — the `mkConSpecClassName` precedent. The interface lives directly under the program root, where no user constructor class can appear (usernames are namespace-qualified into `M_`-prefixed segments by `getIdrisConstructorClassName`). Eligibility (`mkCallbackSig`): arity 1, refs normalised to Object, at least one primitive among parameter/return.
+One generated JVM interface per distinct typed callback signature, named parameter-chars-then-return-char with the `specConDescriptorChar` letters (`L` = exactly `java/lang/Object`): `int apply(int)` → `<programName>/Fn$I$I`. The name is injective over the signature, so **the name is the registry**: `parseCallbackIfaceType` (Asm.idr) decodes any `IRef …/Fn$…` back to its `InferredFunctionType`, and no plan-threading is needed — the `mkConSpecClassName` precedent. The interface lives directly under the program root, where no user constructor class can appear (usernames are namespace-qualified into `M_`-prefixed segments by `getIdrisConstructorClassName`). Eligibility (`mkCallbackSig`): **arity 1 or 2**, refs normalised to Object, at least one primitive among parameter/return. An arity-2 signature decodes to `Fn$D$D$D` (`apply(DD)D`) and so on — the same injective parameter-chars-then-return-char scheme; `parseCallbackIfaceType` accepts up to two parameter slots (`length params <= 2`). See §13.1 for the arity-2 extension.
 
 **The interface extends `Function` with a default bridge** (`Assembler.createIdrisFunctionInterface`):
 
@@ -572,8 +578,8 @@ The bridge is the load-bearing soundness decision: a typed callback value is ass
 A call-site slot is logged as `IRef Fn$…` (instead of `Function`) only when the argument is a **literal `NmLam`** and a typed signature is derivable. `getTermCallbackSigs` (Optimizer.idr) classifies each unerased parameter slot once per program (needs Ctxt) into `AsmState.callbackSlotSigs`, installed on every state before any `inferDef` runs:
 
 - **`CallbackConcrete sig`** — the slot's declared type is a concrete arity-1 function with a primitive (e.g. the `(Int -> Int)` slot of `applyN`); every literal lambda at the slot uses `sig`.
-- **`CallbackPoly`** — an arity-1 function slot that doesn't pin a primitive (type variables like `a -> b` of `map`, or all-reference types). Type arguments are erased in `NamedCExp`, so the signature is derived from the lambda itself: `findLambdaCallbackSig` is a **purely syntactic scan of the lambda body** — the parameter is pinned to a primitive only when every primitive-op observation of it (`NmOp` argument positions with known primitive types) agrees, the return type is read off the body's root expression shape, and anything unclear (no primitive, conflicting observations, shadowed binders) yields nothing. Pure means inference and emission share it verbatim, and it is stable under `rewriteSpecCalls` (which only renames `NmRef` heads).
-- **`CallbackNone`** — everything else (arity ≥2, non-function slots, and **any slot type containing an erased Pi binder**). The erased-binder refusal is load-bearing: a rank-2 slot like `(forall vs . Term vs -> Bool)` is coerced via a lambda that takes the erased argument as a REAL runtime application stage (the caller applies an erased placeholder before the actual argument — see `lambda$shaped$2` in `TTImp.ProcessData`), so the outer stage returns a function; typing it as `Fn$L$I` emits a primitive cast on a function value. `getFnType` skips erased binders, which is why the slot walks like arity-1 — the classification checks for them separately. Found in the stage-2 self-host soak (`NumberFormatException`/`VerifyError` via `shaped`/`calcNaty`); pinned by the `shapedR` case in `tests/jvm/hofspecialisation`.
+- **`CallbackPoly arity`** — a function slot of arity 1 or 2 that doesn't pin a primitive from its declared type (type variables like `a -> b` of `map`, `a -> b -> c` of `zipWith`, or all-reference types). `CallbackPoly` carries the arity (`CallbackPoly Nat`). Type arguments are erased in `NamedCExp`, so the signature is derived from the lambda itself: `findLambdaCallbackSig` is a **purely syntactic scan of the lambda body** — the parameter is pinned to a primitive only when every primitive-op observation of it (`NmOp` argument positions with known primitive types) agrees, the return type is read off the body's root expression shape, and anything unclear (no primitive, conflicting observations, shadowed binders) yields nothing. Pure means inference and emission share it verbatim, and it is stable under `rewriteSpecCalls` (which only renames `NmRef` heads).
+- **`CallbackNone`** — everything else (arity ≥3, non-function slots, and **any slot type containing an erased Pi binder**). The erased-binder refusal is load-bearing: a rank-2 slot like `(forall vs . Term vs -> Bool)` is coerced via a lambda that takes the erased argument as a REAL runtime application stage (the caller applies an erased placeholder before the actual argument — see `lambda$shaped$2` in `TTImp.ProcessData`), so the outer stage returns a function; typing it as `Fn$L$I` emits a primitive cast on a function value. `getFnType` skips erased binders, which is why the slot walks like arity-1 — the classification checks for them separately. Found in the stage-2 self-host soak (`NumberFormatException`/`VerifyError` via `shaped`/`calcNaty`); pinned by the `shapedR` case in `tests/jvm/hofspecialisation`.
 - **Spec-callee slots** (rewritten bodies at emission, recursive self-calls through the spec's own `Fn$…`-typed parameter): the slot already carries the interface type and `parseCallbackIfaceType` fires with zero extra bookkeeping.
 
 Variables, partial applications, `NmDelay`, non-lambda arguments log their natural types → never match a typed spec slot → conservatively stay on the boxed path. (Note Idris eta-expands under-applied function arguments into literal lambdas, so function-valued arguments like `applyN 3 (mkAdder 2) 10` route through the typed path as `\x => mkAdder 2 x`.)
@@ -593,21 +599,121 @@ Two hazards need explicit mirroring (the v1.3 lesson — inference/emission disa
 
 ### Typed apply
 
-Inside a spec body the callback parameter is statically `IRef Fn$…`. `assembleExpr`'s variable-application case (`NmApp _ (NmLocal f) [arg]`) emits `invokeinterface Fn$….apply` with the typed descriptor — argument cast to the typed parameter, primitive result, no boxing. `inferExprApp` mirrors it (returns the sig's return type instead of `IUnknown`). Every other application shape (non-local heads, multi-arg) stays on the boxed path, which remains correct for typed callbacks through the bridge.
+Inside a spec body the callback parameter is statically `IRef Fn$…`. **Arity 1**: `assembleExpr`'s variable-application case (`NmApp _ (NmLocal f) [arg]`) emits `invokeinterface Fn$….apply` with the typed descriptor — argument cast to the typed parameter, primitive result, no boxing. `inferExprApp` mirrors it (returns the sig's return type instead of `IUnknown`). **Arity 2**: a two-argument call `f x y` surfaces as a nested unary application `NmApp (NmApp (NmLocal f) [x]) [y]`; new inference and emission cases collapse the nesting and emit a single `invokeinterface Fn$….apply(t1,t2)` call. The unary case stays arity-1-guarded — a *partial* application of an arity-2 interface (`f x` alone) falls through to the boxed bridge (see §13.1). Every other application shape (non-local heads, over-application) stays on the boxed path, which remains correct for typed callbacks through the bridge.
 
 ### Where the win is
 
 - Numeric HOFs (`applyN`, `iterate`): all four box/unbox operations per callback call disappear and the lambda implementation method is statically `int(int)`.
 - `map`-style HOFs over lists: synthetic CONS slots are never refined (§12 Phase 2d), so the element is Object in the spec body and the typed apply costs one explicit unbox on the argument — but the primitive result flows unboxed into a `CONS$I$L` typed construction and the implementation-internal unbox+box disappears.
+- Arity-2 numeric HOFs (`zipWith`, `foldl`): the two-argument callback (`(+)`, `(*)`) becomes a single `Fn$D$D$D.apply(DD)D` interface call, and a primitive result flows unboxed into the synthetic `CONS$D$L` result cell (§13.1).
+
+### 13.1 Arity-2 callbacks
+
+The arity-1 machinery described above left two-argument callbacks (`zipWith`, `foldl` accumulators) on the boxed `Function` path. The machinery now extends to arity 2, reusing the same name-is-the-registry interface scheme:
+
+- **Type layer (`Asm.idr`).** `CallbackPoly` carries arity (`CallbackPoly Nat`); `mkCallbackSig` / `parseCallbackIfaceType` accept up to two parameter slots. Interface naming is unchanged — `Fn$D$D$D` is `apply(DD)D`.
+- **Nested two-lambda shape rule.** An arity-2 signature requires the literal argument to be the nested shape `NmLam p1 (NmLam p2 body)`. `sigMatchesLambdaShape` (Optimizer.idr) guards the inference dispatch; emission `asmCrash`es on a mismatch (which cannot happen — `rewriteSpecCalls` only fires when the logged type already matched the shape). Both parameters live in **one** lambda scope: `inferCallbackLambda` dissolves the inner `NmLam`, and emission collapses to a single 2-parameter implementation method.
+- **Partial-application bridge (`Assembler.java`).** The arity-2 interface's default boxed `apply(Object)` cannot perform the whole 2-arg call from one argument, so it returns a companion **`<iface>$P`** partial-application class (`createIdrisFunctionPartialClass`) holding the typed callback and the typed first argument; that object's own `apply` supplies the second argument and invokes the typed SAM. This keeps an arity-2 typed callback behaviourally identical to the curried natural `Function` chain it replaces, so it stays sound wherever a generic `Function` flows.
+- **CSE interaction (`inlineCallbackLambdas`).** Common-subexpression elimination lifts a lambda shared across call sites (e.g. `(+)` used twice) into a nil-arity `csegen` CAF, so the callback slot sees `NmApp cse []` rather than a literal `NmLam` — and no spec is discovered. `inlineCallbackLambdas` (run at the **start** of `optimize`, before tail-rec and `uniquifySiteFcs`) inlines a nil-arity literal-lambda CAF back at direct-call argument positions when the lambda derives a typed signature. Allocation-neutral: non-capturing `invokedynamic` closures are singletons, so re-inlining doesn't multiply allocations.
+- **CONS unboxing falls out for free.** Once `zipWith$sp0`'s CONS head infers `IDouble` through the typed apply, the existing constructor plan emits `CONS$D$L` with an unboxed `double` field (synthetic List family, §11–§12). No new constructor machinery is needed.
+
+Covered by `tests/jvm/hofspecialisation` (decl-driven: typed interface shape — extends `Function`, typed SAM, default bridge — `$sp` variants with `Fn$I$I` slots for `applyN`/`twice`/`hof`/`countdown`, typed apply with no boxing in the recursive spec body, primitive-typed lambda implementation methods, natural method retention, and a runtime bridge escape through an Object constructor slot) and `tests/jvm/hofpolyspecialisation` (polymorphic: `myMap$sp0` with a lambda-derived `Fn$I$I` slot, typed apply, the int result flowing unboxed into `CONS$I$L` construction, and an all-reference lambda staying natural). Arity-2 is exercised by the JMH `matMul`/`zipWith` paths (§13.2): bytecode confirms `Fn$D$D$D.apply:(DD)D` and `new CONS$D$L` inside `zipWith$sp0`.
+
+### 13.2 Benchmarks (JMH)
+
+A JMH harness (`benchmark/jmh`, `BenchmarkMain` with `matMul` and `sievePrimes`) measures allocation rate and throughput against the 0.8.0 baseline. Against that baseline, `matMul` allocation dropped from **10.48 → 5.47 MB/op (−48%)** with throughput roughly flat (768 → 720 ops/s, −6%); `sieve` allocation is flat. JFR profiling of the post-optimisation `matMul` shows the remaining cost is now dominated by `countFrom`/`takeUntil` `MemoizedDelayed` stream thunks for range generation (~50%) and the irreducible `CONS$D$L` result cells (~39%) — both separate optimisation targets (stream fusion / direct range loops), not callback boxing.
+
+### Remaining boxing (future work)
+
+- **Spec bodies still read list cells via the natural `IdrisObject.getProperty`**, which boxes the primitive slots of `CONS$D$L`, because list parameters stay `Object`-typed. Family-typed parameters (`List$D$L` + `getDouble0` accessors) would require spec **return** types to be refined to family interfaces across whole call chains — a strictly stronger mechanism than today's single-slot narrowing.
+- **Range generation** (`countFrom` / `takeUntil` streams) allocates a `MemoizedDelayed` plus a closure per element; stream fusion or direct range loops would address the new #1 site in both benchmarks.
 
 ### Scope and deferred work
 
-Arity-1 callbacks only (arity ≥2 surfaces partly as curried `Function` chains through `Functions.curry`); `DelayedLambda` out of scope. Deferred: arity-2 (`BiFunction`, fold accumulators — the naming scheme already accommodates), let-bound local lambdas typed as callback interfaces, `NmRef`-callee observations in `findLambdaCallbackSig` (currently primitive ops only).
+Arity 1 and 2 only (arity ≥3 surfaces partly as curried `Function` chains through `Functions.curry`); `DelayedLambda` out of scope. Deferred: let-bound local lambdas typed as callback interfaces, and `NmRef`-callee observations in `findLambdaCallbackSig` (currently primitive ops only).
 
-Covered by `tests/jvm/hofspecialisation` (decl-driven: typed interface shape — extends `Function`, typed SAM, default bridge — `$sp` variants with `Fn$I$I` slots for `applyN`/`twice`/`hof`/`countdown`, typed apply with no boxing in the recursive spec body, primitive-typed lambda implementation methods, natural method retention, and a runtime bridge escape through an Object constructor slot) and `tests/jvm/hofpolyspecialisation` (polymorphic: `myMap$sp0` with a lambda-derived `Fn$I$I` slot, typed apply, the int result flowing unboxed into `CONS$I$L` construction, and an all-reference lambda staying natural).
+## 14. Family-typed return refinement (v2.1)
 
-## 14. Future work (v3 and beyond)
+### Problem
+
+The parameter-narrowing machinery (§11–§12) only fires when a call site's
+argument is logged as a family interface — which `inferExprCon` does for a
+**direct construction** (`Cons 5 acc` → `List$I$L`).  When the argument is
+instead a **function result** (`useBox (mkBox 5)`), the call logs `mkBox`'s
+return type, which is the natural `Object` — so the consumer never earns a
+family-typed parameter spec and its pattern match keeps reading fields with
+boxed `IdrisObject.getProperty` + `Conversion.toInt`.  This was the largest
+remaining boxing site for user data types.
+
+### Refinement (`refineNaturalReturn`, Codegen.idr)
+
+When a natural producer's declared result is a single TCon `T` and every
+data-carrying construction in its body belongs to **one** family
+instantiation of `T`, the function's return type is refined from `Object`
+to that family interface (`Box$F`, `Tree$F`) — or, for a RECORD/UNIT
+producer, the lone DCon spec class.  The refined type:
+
+- persists on the per-name `AsmState` (`getCurrentFunction`), so it is read
+  back by the next plan pass, by the `naturalConsLive` fixpoint, and by
+  final assembly (`assembleNameFcStateRefs` seeds the natural method from
+  `getCurrentFunction`, not the term type — so no extra threading is
+  needed), and
+- propagates to callers via `findFunctionType`: `inferExprApp` returns the
+  refined type as the call's inferred type, so `useBox (mkBox 5)` now logs
+  `Box$F` for `useBox`'s slot and earns `useBox$sp(Box$F)`, whose `Full`
+  alt reads with the typed `getInt0/1/2` accessors.
+
+Run as a step in the `buildSpecialisationPlan` fixpoint right after
+`inferDef`; it sets `naturalTypeChanged`, so a producer's refinement
+re-dirties its consumers until the plan converges (idempotent —
+`isObjectType` is false once refined).
+
+### Why type-directed, and the soundness gate
+
+The naive alternative — read the body's inferred type — fails because
+`combineSwitchTypes` collapses any `case` with differing branch types to
+`Object`, so a producer with a nullary base case (`Empty`/`Leaf`) infers
+`Object`.  Instead the **declared result type** is the soundness gate
+(`getResultTypeCon`, Optimizer.idr): when the result is a single TCon `T`,
+every value the function returns is a `T`, and every member of an active
+family instantiation implements its interface (data-carrying spec cells
+directly; nullary/sibling naturals via `computeNaturalToTConIfaces`).  So
+an `Object`-typed tail (a returned `Leaf`, a parameter) is cast to the
+interface at `areturn` by the existing `asmCast`/`loadVar` return path and
+succeeds at runtime.  The body's construction sites (`conSiteLog`) only
+choose **which** instantiation; the type gate guarantees soundness.
+
+Conservative refusals: synthetic shapes (CONS/JUST/...) are skipped — their
+natural class is essentially always live program-wide (boxed prelude
+lists), so the family-interface typed read is blocked by `naturalConsLive`
+anyway (this is the §12 "recursive slots for synthetic shapes" limitation);
+a body building more than one instantiation of `T`; a non-TCon result head;
+and ordinary DCons that haven't pinned an instantiation interface
+(`tconClassName == ""`).
+
+### Effect
+
+`mkBox`'s descriptor becomes `Box$F mkBox(int)`; the consumer
+`useBox (mkBox 5)`, whose argument is a *call* (not a literal
+construction), routes through `useBox$sp(Box$F)` and reads `Full`'s fields
+with `getInt0/1/2` — no boxing.  For a recursive producer (`build : Int ->
+Tree`), the self-call returns `Tree$F` directly and feeds the `Node` ctor's
+recursive slot cast-free; only the nullary `Leaf` branches pay the single
+`Object → Tree$F` cast.  Covered by `tests/jvm/conreturnfamily` (the
+`Box`/`mkBox`/`useBox` chain) and the updated `tests/jvm/conrecursiveslots`
+(`build` now returns `Tree$F`).
+
+### Scope and deferred work
+
+Natural producers only — a **spec's** refined return does not reach its
+callers (callers infer against the natural callee; `rewriteSpecCalls` only
+renames the head afterward), so cross-spec-chain propagation is out of
+scope.  Synthetic-shape lists still read boxed (needs the CONS/RCONS
+split-by-recursion of §12).
+
+## 15. Future work (v3 and beyond)
 
 - **Multi-class spec placement.** Spec currently shares the natural method's class; consider moving very-hot specs to a sibling class to keep the main class size bounded.
-- **Benchmarks.** Add a numeric microbenchmark (sieve, matrix mul) and measure allocation rate before/after with JFR or async-profiler.
+- **Synthetic-shape family reads.** Splitting the intrinsic `_builtin/CONS` per source type (or proving per-instance recursion) would let prelude-`List` spec bodies use typed accessors — the boxing §14 leaves on the table for lists.  Full analysis in [recursive-slots-synthetic-shapes.md](recursive-slots-synthetic-shapes.md).
+- **Stream/range fusion.** The JMH profiles (§13.2) now show `countFrom`/`takeUntil` `MemoizedDelayed` thunks dominating; direct range loops or stream fusion is the next allocation win, orthogonal to specialisation.
 - **Configurable spec budget.** A flag to cap the number of specs per function or per class for users who want predictable compile times over peak runtime.

--- a/src/Compiler/Jvm/Asm.idr
+++ b/src/Compiler/Jvm/Asm.idr
@@ -686,6 +686,14 @@ record AsmState where
     -- alongside the specialisation plan, since inference has no Ctxt
     -- access.
     callbackSlotSigs : SortedMap String (List CallbackSlot)
+    -- The body's inferred return type from the most recent `inferDef` on
+    -- this state (the result of `inferExpr` on the function body, which is
+    -- otherwise discarded).  Read by `computeReturnRefinement` (Codegen) as
+    -- the primary source for family-typed return refinement — it already
+    -- reflects the spec plan (a pass-through `f x = g x` infers as `g`'s
+    -- refined spec return), covering producers the construction-site scan
+    -- misses.  Reset to `IUnknown` by `inferFunctionType`.
+    inferredReturnType : InferredType
 
 namespace AsmState
   export
@@ -695,7 +703,7 @@ namespace AsmState
     scopes <- ArrayList.new {elemTy=Scope}
     lineNumberLabels <- Map.newTreeMap {key=Int} {value=String}
     let function = MkFunction name (MkInferredFunctionType IUnknown []) (subtyping scopes) 0 (NmCrash emptyFC "uninitialized function")
-    pure $ MkAsmState function SortedMap.empty SortedMap.empty 0 0 0 0 lineNumberLabels assembler [] [] SortedSet.empty SortedMap.empty SortedMap.empty
+    pure $ MkAsmState function SortedMap.empty SortedMap.empty 0 0 0 0 lineNumberLabels assembler [] [] SortedSet.empty SortedMap.empty SortedMap.empty IUnknown
 
   export
   fromIdrisName : Name -> IO AsmState
@@ -2690,6 +2698,14 @@ getConSiteLog = conSiteLog <$> getState
 export
 resetConSiteLog : {auto stateRef: Ref AsmState AsmState} -> Core ()
 resetConSiteLog = updateState $ { conSiteLog := [] }
+
+export
+getInferredReturnType : {auto stateRef: Ref AsmState AsmState} -> Core InferredType
+getInferredReturnType = inferredReturnType <$> getState
+
+export
+setInferredReturnType : {auto stateRef: Ref AsmState AsmState} -> InferredType -> Core ()
+setInferredReturnType ty = updateState $ { inferredReturnType := ty }
 
 export
 getNaturalConsLive : {auto stateRef: Ref AsmState AsmState} -> Core (SortedSet Name)

--- a/src/Compiler/Jvm/Codegen.idr
+++ b/src/Compiler/Jvm/Codegen.idr
@@ -2861,30 +2861,40 @@ assembleNameFcStateRefs : {auto c : Ref Ctxt Defs}
                         -> ConSpecialisationPlan
                         -> SortedSet Name
                         -> SortedMap String (List String)
+                        -> (liveFns : SortedSet Name)
                         -> SortedMap String NamedDef
                         -> LazyList (Name, FC, Ref AsmState AsmState) -> Core ()
-assembleNameFcStateRefs _ _ _ _ _ [] = pure ()
-assembleNameFcStateRefs plan conPlan natLive natIfaces defs ((name, fc, stateRef) :: rest) = do
+assembleNameFcStateRefs _ _ _ _ _ _ [] = pure ()
+assembleNameFcStateRefs plan conPlan natLive natIfaces liveFns defs ((name, fc, stateRef) :: rest) = do
   setSpecialisationPlan {stateRef} plan
   setConSpecialisationPlan {stateRef} conPlan
   setNaturalConsLive {stateRef} natLive
   setNaturalToTConIfaces {stateRef} natIfaces
+  -- Dead-function elimination: emit the natural method only when it's live
+  -- (reachable in the rewritten graph).  A natural whose every caller was
+  -- rewritten to a spec is never invoked; skipping it also drops the natural
+  -- constructor classes that only its dead body builds.  `liveFns` is a
+  -- superset of genuinely-callable functions (every call / first-class ref
+  -- from a root — `main`/exports — is followed), so this never removes a
+  -- method that is actually used.  Specs are skipped likewise when no live
+  -- body references them.
+  --
   -- Mirror assembleSpec for the natural method: re-run inferFunctionType +
   -- inferDef so the body is rewritten with the FINAL plan right before it's
-  -- lowered to bytecode.  buildSpecialisationPlan's iteration also rewrites
-  -- the body, but only as a side effect of fixed-point convergence — doing
-  -- it explicitly here makes the assembly pipeline symmetric with
-  -- assembleSpec and immune to any future change in the iteration order.
-  case SortedMap.lookup (jvmSimpleName name) defs of
-    Just def => do
-      initialFunctionType <- inferredFunctionType <$> getCurrentFunction {stateRef}
-      inferFunctionType {stateRef} (Just initialFunctionType) def
-      inferDef {stateRef}
-    Nothing => pure ()
-  assemble {stateRef=stateRef} name fc
+  -- lowered to bytecode.
+  when (SortedSet.contains name liveFns) $ do
+    case SortedMap.lookup (jvmSimpleName name) defs of
+      Just def => do
+        initialFunctionType <- inferredFunctionType <$> getCurrentFunction {stateRef}
+        inferFunctionType {stateRef} (Just initialFunctionType) def
+        inferDef {stateRef}
+      Nothing => pure ()
+    assemble {stateRef=stateRef} name fc
   cbSigs <- getCallbackSlotSigs {stateRef}
-  traverse_ (assembleSpec plan conPlan natLive natIfaces cbSigs) (fromMaybe [] $ SortedMap.lookup name plan)
-  assembleNameFcStateRefs plan conPlan natLive natIfaces defs rest
+  traverse_ (\sp => when (SortedSet.contains sp.name liveFns) $
+                      assembleSpec plan conPlan natLive natIfaces cbSigs sp)
+            (fromMaybe [] $ SortedMap.lookup name plan)
+  assembleNameFcStateRefs plan conPlan natLive natIfaces liveFns defs rest
 
 getNamedDefsByName : String -> LazyList (Name, FC, Ref AsmState AsmState) -> Core (SortedMap String NamedDef)
 getNamedDefsByName programName nameFcStateRefs = go SortedMap.empty nameFcStateRefs where
@@ -3420,16 +3430,22 @@ buildSpecialisationPlan programName defs stateRefs reachable = iterate
       else case matchConSpec conName paramTypes conPlan of
         Nothing => pure Nothing
         Just sc =>
-          let mR = if isRecordCon conInfo
-                     then Just (IRef sc.specClassName Class [])
-                     else if sc.tconClassName /= ""
-                            then Just (IRef sc.tconClassName Interface [])
-                            else Nothing
-          in case mR of
-            Nothing => pure Nothing
-            Just r => do
-              mTc <- findTConForDCon conName
-              pure $ (\tc => (tc, r)) <$> mTc
+          -- Refine ONLY to a TCon family INTERFACE — a marker every member
+          -- of the family implements (data-carrying specs directly; natural
+          -- siblings via `computeNaturalToTConIfaces`), so a `checkcast` to
+          -- it always succeeds.  NOT a record's concrete DCon spec class:
+          -- a record's spec class is per-site field-type inference
+          -- (`MkPFR$L$L$I` where the `Int` field was inferred primitive vs
+          -- natural `MkPFR` where it was Object), so refining a return to
+          -- one concrete class commits consumers to it while a sibling
+          -- value flows in -> ClassCastException (found self-hosting
+          -- `Idris.Package.partitionOpts`; same family as the §7
+          -- FC-collision miscompile).  Records therefore never get a
+          -- refined return — `tconClassName == ""` for them.
+          if sc.tconClassName == "" then pure Nothing
+          else do
+            mTc <- findTConForDCon conName
+            pure $ (\tc => (tc, IRef sc.tconClassName Interface [])) <$> mTc
       where
         slotMatch : InferredType -> InferredType -> Bool
         slotMatch spec arg = if isPrimitive spec then spec == arg else not (isPrimitive arg)
@@ -3439,6 +3455,22 @@ buildSpecialisationPlan programName defs stateRefs reachable = iterate
           entries <- SortedMap.lookup n plan
           find (\sc => length sc.paramTypes == length argTypes
                        && all (uncurry slotMatch) (zip sc.paramTypes argTypes)) entries
+
+    -- True when `ty` is a NON-SYNTHETIC TCon family INTERFACE registered in
+    -- `conPlan` (some spec's `tconClassName`).  Used to validate the body's
+    -- inferred return type as a refinement target: only family interfaces
+    -- qualify — never a record's concrete spec class (the §14 record CCE), a
+    -- callback `Fn$…`, `IdrisObject`, or `java/lang/Object` (none are a
+    -- `tconClassName`).  Synthetic families (`List`/`Maybe`/`Nat`) are also
+    -- excluded: their natural class is essentially always live program-wide
+    -- (boxed prelude lists), so a family-typed read is blocked by
+    -- `naturalConsLive` anyway — refining to them is churn with no payoff
+    -- (matches the construction-site path's synthetic skip).
+    isFamilyIface : ConSpecialisationPlan -> InferredType -> Bool
+    isFamilyIface plan (IRef cls _ _) =
+      cls /= "" && any (\sc => sc.tconClassName == cls && isNothing (syntheticTConName sc.conInfo))
+                       (snd =<< SortedMap.toList plan)
+    isFamilyIface _ _ = False
 
     -- Family-typed return refinement (design doc §14).  When a natural
     -- producer's declared result is a single TCon `T` and every
@@ -3461,36 +3493,112 @@ buildSpecialisationPlan programName defs stateRefs reachable = iterate
     -- Conservative: a body building more than one instantiation of `T`, a
     -- non-TCon result head, or any synthetic-shape construction leaves the
     -- return unrefined.  Idempotent, so the fixpoint converges.
-    refineNaturalReturn : {auto stateRef : Ref AsmState AsmState}
-                       -> ConSpecialisationPlan -> Name -> Core ()
-    refineNaturalReturn conPlan name = do
+    -- Compute the family-interface return refinement for whatever function
+    -- is currently inferred on `stateRef` (its body's construction sites
+    -- live in `conSiteLog`).  `originalName` is the ORIGINAL Idris name
+    -- (a spec reuses the original `NamedDef`, so its result TCon comes from
+    -- the original type).  Returns `Just R` when the body builds exactly
+    -- one family instantiation of the result TCon and the result is a
+    -- refinement candidate, else `Nothing`.
+    --
+    -- `requireMonomorphic` applies the NON-PARAMETRIC gate, used for the
+    -- NATURAL method only: the natural method is type-erased and serves
+    -- every instantiation, so it may be refined only when its result TCon
+    -- has one runtime instantiation (`getTypeConArity == 0`).  A SPEC has a
+    -- concrete instantiation (its parameter types are fixed), so it passes
+    -- `False`: `mkTree$sp0(int)` genuinely returns `Tree Int` and may carry
+    -- `Tree$F$I`.  Under-determined spec instantiations are still rejected
+    -- by the unique-family check (`returnFamilyOf` returns `Nothing` for
+    -- `tconClassName == ""`).
+    computeReturnRefinement : {auto stateRef : Ref AsmState AsmState}
+                           -> ConSpecialisationPlan -> Name -> (requireMonomorphic : Bool)
+                           -> Core (Maybe InferredType)
+    computeReturnRefinement conPlan originalName requireMonomorphic = do
       fn <- getCurrentFunction
       let fty = inferredFunctionType fn
       -- Only the generic Object return is a refinement candidate;
       -- `isObjectType` is true for `inferredObjectType`/`IUnknown` and
       -- false once already refined to an `IRef T$F`, so this is idempotent
       -- and the fixpoint converges.
-      when (isObjectType (returnType fty)) $ do
-        conLog <- getConSiteLog
-        -- Dedup construction sites by (DCon, paramTypes): cross-pass
-        -- accumulation re-adds each site, and `paramTypes` is ref-
-        -- normalised so the keys are stable.
-        let sites = nubBy (\(n1, _, p1), (n2, _, p2) => n1 == n2 && p1 == p2)
-                          (map (\(_, n, ci, _, ps) => (n, ci, ps)) conLog)
-        candidates <- traverse (\(n, ci, ps) => returnFamilyOf conPlan ci n ps) sites
-        case mapMaybe id candidates of
-          [] => pure ()
-          families => do
-            Just retTcon <- getResultTypeCon name
-              | Nothing => pure ()
-            let matching = nub $ mapMaybe (\(tc, r) => if tc == retTcon then Just r else Nothing) families
-            case matching of
-              [r] => do
-                let fn' = { inferredFunctionType := { returnType := r } fty } fn
-                setCurrentFunction fn'
-                jname <- getRootMethodName
-                coreLift $ addFunction jname fn'
-              _ => pure ()
+      if not (isObjectType (returnType fty))
+        then pure Nothing
+        else do
+          -- PRIMARY source: the body's inferred return type (captured by
+          -- inferDef).  When it's a TCon family interface, the body provably
+          -- produces that family (inference and emission agree), so the
+          -- return may be refined to it directly — no monomorphic gate
+          -- needed (a polymorphic body infers Object, not a concrete
+          -- family).  This covers pass-through producers (`f x = g x`, whose
+          -- body infers as `g`'s spec return), direct constructions, and
+          -- uniform-branch cases — the construction-site scan below is a
+          -- FALLBACK for recursive producers whose `Leaf`-base branch makes
+          -- `combineSwitchTypes` collapse the body type to Object.
+          bodyTy <- getInferredReturnType
+          if isFamilyIface conPlan bodyTy
+            then pure (Just bodyTy)
+            else do
+              conLog <- getConSiteLog
+              -- Dedup construction sites by (DCon, paramTypes): cross-pass
+              -- accumulation re-adds each site, and `paramTypes` is ref-
+              -- normalised so the keys are stable.
+              let sites = nubBy (\(n1, _, p1), (n2, _, p2) => n1 == n2 && p1 == p2)
+                                (map (\(_, n, ci, _, ps) => (n, ci, ps)) conLog)
+              candidates <- traverse (\(n, ci, ps) => returnFamilyOf conPlan ci n ps) sites
+              case mapMaybe id candidates of
+                [] => pure Nothing
+                families => do
+                  Just retTcon <- getResultTypeCon originalName
+                    | Nothing => pure Nothing
+                  keepGoing <- if requireMonomorphic
+                                 then (== Just 0) <$> getTypeConArity retTcon
+                                 else pure True
+                  if not keepGoing
+                    then pure Nothing
+                    else case nub $ mapMaybe (\(tc, r) => if tc == retTcon then Just r else Nothing) families of
+                      [r] => pure (Just r)
+                      _   => pure Nothing
+
+    -- Family-typed return refinement (design doc §14).  When a NATURAL
+    -- producer's declared result is a single non-parametric TCon `T` and
+    -- every data-carrying construction in its body belongs to one family
+    -- instantiation of `T`, refine its return type from Object to that
+    -- family interface.  The refined type persists on the per-name AsmState
+    -- — read back next pass, by the natLive fixpoint, and by final assembly
+    -- (`assembleNameFcStateRefs` seeds from `getCurrentFunction`) — and
+    -- propagates to callers via `findFunctionType`.  (Parametric producers
+    -- propagate instead through per-spec refinement; see the spec loop in
+    -- `step` and the plan consultation in `inferExprApp`.)
+    --
+    -- Soundness rests on the result-type gate: every value the function
+    -- returns is a `T`, and every member of an active family instantiation
+    -- implements its interface (siblings via `computeNaturalToTConIfaces`),
+    -- so an Object-typed tail (a returned `Nil`/parameter) is cast to the
+    -- interface at `areturn` and succeeds.
+    refineNaturalReturn : {auto stateRef : Ref AsmState AsmState}
+                       -> ConSpecialisationPlan -> Name -> Core ()
+    refineNaturalReturn conPlan name = do
+      Just r <- computeReturnRefinement conPlan name True
+        | Nothing => pure ()
+      fn <- getCurrentFunction
+      let fn' = { inferredFunctionType := { returnType := r } (inferredFunctionType fn) } fn
+      setCurrentFunction fn'
+      jname <- getRootMethodName
+      coreLift $ addFunction jname fn'
+
+    -- Replace the return type of the spec named `specName` (under function
+    -- `fnName`) in the plan.  Used after refining a spec's return so
+    -- `assembleSpec`/`preRegisterSpecs` emit the refined descriptor and
+    -- `inferExprApp` observes it when matching a call site to the spec.
+    setSpecReturn : Name -> Name -> InferredType -> SpecialisationPlan -> SpecialisationPlan
+    setSpecReturn fnName specName r plan =
+      case SortedMap.lookup fnName plan of
+        Nothing => plan
+        Just specs => SortedMap.insert fnName (map upd specs) plan
+      where
+        upd : SpecialisedSignature -> SpecialisedSignature
+        upd s = if s.name == specName
+                  then { type := { returnType := r } s.type } s
+                  else s
 
     step : PlanState -> Name -> Core (PlanState, StepEffects)
     step ps name = do
@@ -3546,13 +3654,37 @@ buildSpecialisationPlan programName defs stateRefs reachable = iterate
                 setCallbackSlotSigs {stateRef = specRef} !(getCallbackSlotSigs {stateRef = asmStateRef})
                 inferFunctionType {stateRef = specRef} (Just initialFunctionType) def
                 inferDef {stateRef = specRef}
+                -- Spec-return propagation: refine THIS spec's return to its
+                -- own family instantiation (no monomorphic gate — the spec's
+                -- instantiation is concrete) and write it back into the plan
+                -- entry, so `assembleSpec`/`preRegisterSpecs` emit the
+                -- refined descriptor and `inferExprApp` uses it when a call
+                -- site matches this spec by parameter types.  Each spec gets
+                -- its OWN correct return, so parametric producers propagate
+                -- without the natural-return inherited-mismatch hazard.
+                mSpecR <- computeReturnRefinement {stateRef = specRef} p.conPlan name False
+                let specRetChanged = case mSpecR of
+                                       Just r  => fnType.returnType /= r
+                                       Nothing => False
+                let pUpd : PlanState
+                    pUpd = case mSpecR of
+                             Just r  => { funPlan := setSpecReturn name specFnName r p.funPlan } p
+                             Nothing => p
                 specType <- inferredFunctionType <$> getCurrentFunction {stateRef = specRef}
                 let specTypeChanged = maybe True (/= specType) prevSpecType
                 sites <- getCallSiteLog {stateRef = specRef}
-                (p', keys') <- foldSites p sites
+                (p', keys') <- foldSites pUpd sites
                 conSites <- getConSiteLog {stateRef = specRef}
                 (p'', cons') <- foldConSites p' conSites
-                pure (p'', keys ++ keys', cons ++ cons', tyCh || specTypeChanged))
+                -- A spec-return change must re-dirty the callee's callers
+                -- (their `inferExprApp` now sees the refined spec return), so
+                -- surface it through `specKeys` — which both makes
+                -- `nextDirty.planGrew` true (ungating type ripples) and adds
+                -- `name`'s reverse-deps.  Monotone (Object→family once per
+                -- spec), so it can't loop.
+                let retKeys = if specRetChanged then [name] else []
+                pure (p'', keys ++ keys' ++ retKeys, cons ++ cons',
+                      tyCh || specTypeChanged || specRetChanged))
             (pure (ps2, newKeys1, newCons1, naturalTypeChanged))
             allSpecs
           pure (psN, MkStepEffects keys cons (if anyTypeChanged then [name] else []))
@@ -3642,14 +3774,33 @@ buildSpecialisationPlan programName defs stateRefs reachable = iterate
 -- primitive slot back to Object and accidentally *satisfy* a ref-slot
 -- spec match that a previous pass rejected.  Once a constructor is
 -- observed natural-live under any candidate set, it stays live.
+-- `roots` are the names callable from outside the rewritten call graph
+-- (`main` + exports).  A natural function whose name appears in NO rewritten
+-- body and isn't a root is never invoked, so its construction sites never
+-- execute and must NOT count toward natural-liveness — this is what lets a
+-- POLYMORPHIC producer (`mkTree : a -> Tree a`, whose only caller `mkTree 7`
+-- is rewritten to `mkTree$sp0`) drop out: its natural body builds a natural
+-- `Node`, but that body is dead, so `Node` is not natural-live and a
+-- consumer of `mkTree$sp0`'s `Tree$F$I` result can read with typed
+-- accessors.  Soundness is preserved because the union accumulates the
+-- FINAL pass's live-function contributions (the converged rewriting used by
+-- emission), so a typed read implies no LIVE function builds the natural
+-- class under that rewriting.
 computeNaturalConsLive : {auto c : Ref Ctxt Defs} -> {auto s : Ref Syn SyntaxInfo}
                      -> SortedMap String NamedDef
                      -> SortedMap String (Ref AsmState AsmState)
                      -> SpecialisationPlan
                      -> ConSpecialisationPlan
-                     -> List Name -> Core (SortedSet Name)
-computeNaturalConsLive defs stateRefs plan conPlan reachable =
-    loop (buildReverseDeps defs reachable) (SortedSet.fromList reachable) SortedSet.empty
+                     -> List Name -> (roots : SortedSet Name)
+                     -> Core (SortedSet Name, SortedSet Name)
+computeNaturalConsLive defs stateRefs plan conPlan reachable roots =
+    -- `loop` grows the live FUNCTION set incrementally and returns it
+    -- (alongside `natLive`) — the converged reachability closure over the
+    -- rewritten graph, used by emission to drop dead functions (natural
+    -- methods whose every caller was rewritten to a spec, and the natural
+    -- constructor classes only those dead bodies build).
+    loop (buildReverseDeps defs reachable) (SortedSet.fromList reachable)
+         SortedSet.empty SortedMap.empty SortedMap.empty roots
   where
     slotMatch : InferredType -> InferredType -> Bool
     slotMatch spec arg =
@@ -3668,17 +3819,26 @@ computeNaturalConsLive defs stateRefs plan conPlan reachable =
          then Nothing
          else Just name
 
+    -- Drain a function's inference and report (a) its construction sites and
+    -- (b) the names its REWRITTEN body references (call heads + first-class
+    -- `NmRef`s) — the latter feed the liveness set.  `refsExp` also collects
+    -- constructor names; harmless, since liveness is queried by function name.
     drain : {auto stateRef : Ref AsmState AsmState} -> InferredFunctionType
-         -> NamedDef -> Core (List (Name, List InferredType))
+         -> NamedDef -> Core (List (Name, List InferredType), SortedSet Name)
     drain initialFunctionType def = do
       inferFunctionType (Just initialFunctionType) def
       inferDef
       log <- getConSiteLog
-      pure $ map (\(_, n, _, _, ts) => (n, ts)) log
+      body <- optimizedBody <$> getCurrentFunction
+      pure (map (\(_, n, _, _, ts) => (n, ts)) log, refsExp SortedSet.empty body)
 
+    -- A per-function "node" of the rewritten call graph: (function name, its
+    -- construction sites, the names its rewritten body references).  Both
+    -- natural functions and specs are nodes; the name is the site ORIGIN so
+    -- `loop` can drop sites in dead (unreachable) functions.
     gatherForSpec : SortedSet Name -> NamedDef -> SortedMap String (List CallbackSlot)
                  -> SpecialisedSignature
-                 -> Core (List (Name, List InferredType), Bool)
+                 -> Core (Name, List (Name, List InferredType), SortedSet Name, Bool)
     gatherForSpec current def cbSigs (MkSpecialisedSig specName specDef specType) = do
       let specParams = specType.parameterTypes
       let arity = case def of
@@ -3696,11 +3856,12 @@ computeNaturalConsLive defs stateRefs plan conPlan reachable =
       setConSpecialisationPlan {stateRef = specRef} conPlan
       setNaturalConsLive {stateRef = specRef} current
       setCallbackSlotSigs {stateRef = specRef} cbSigs
-      sites <- drain {stateRef = specRef} specInitial specDef
+      (sites, refs) <- drain {stateRef = specRef} specInitial specDef
       specType' <- inferredFunctionType <$> getCurrentFunction {stateRef = specRef}
-      pure (sites, maybe True (/= specType') prevSpecType)
+      pure (specName, sites, refs, maybe True (/= specType') prevSpecType)
 
-    gatherFor : SortedSet Name -> Name -> Core (List (Name, List InferredType), Bool)
+    gatherFor : SortedSet Name -> Name
+             -> Core (List (Name, List (Name, List InferredType), SortedSet Name), Bool)
     gatherFor current name = do
       let nameStr = jvmSimpleName name
       let Just asmStateRef = SortedMap.lookup nameStr stateRefs
@@ -3711,54 +3872,89 @@ computeNaturalConsLive defs stateRefs plan conPlan reachable =
       setConSpecialisationPlan {stateRef = asmStateRef} conPlan
       setNaturalConsLive {stateRef = asmStateRef} current
       initialFunctionType <- inferredFunctionType <$> getCurrentFunction {stateRef = asmStateRef}
-      naturalSites <- drain {stateRef = asmStateRef} initialFunctionType def
+      (naturalSites, natRefs) <- drain {stateRef = asmStateRef} initialFunctionType def
       finalType <- inferredFunctionType <$> getCurrentFunction {stateRef = asmStateRef}
       let specs = fromMaybe [] $ SortedMap.lookup name plan
       cbSigs <- getCallbackSlotSigs {stateRef = asmStateRef}
       specResults <- traverse (gatherForSpec current def cbSigs) specs
-      pure ( naturalSites ++ join (map fst specResults)
-           , finalType /= initialFunctionType || any snd specResults)
+      let nodes = (name, naturalSites, natRefs)
+                    :: map (\(sn, s, r, _) => (sn, s, r)) specResults
+      pure (nodes, finalType /= initialFunctionType || any (\(_, _, _, c) => c) specResults)
 
-    onePass : SortedSet Name -> List Name -> Core (SortedSet Name, List Name)
+    onePass : SortedSet Name -> List Name
+           -> Core (List (Name, List (Name, List InferredType), SortedSet Name), List Name)
     onePass current names = do
-      results <- the (Core (List (List (Name, List InferredType), Maybe Name))) $
-                   traverse (\n => do (sites, tyCh) <- gatherFor current n
-                                      pure (sites, if tyCh then Just n else Nothing))
+      results <- the (Core (List (List (Name, List (Name, List InferredType), SortedSet Name), Maybe Name))) $
+                   traverse (\n => do (nodes, tyCh) <- gatherFor current n
+                                      pure (nodes, if tyCh then Just n else Nothing))
                             names
-      -- `join` is List's tail-recursive O(n) bind; `concat` is
-      -- `foldl (<+>)` and re-copies the accumulator per chunk, which is
-      -- quadratic over `reachable` and dominated the build (50% of all
-      -- samples landed here before the change).
-      let sites = join (map Builtin.fst results)
-      pure (SortedSet.fromList (mapMaybe needsNatural sites), mapMaybe Builtin.snd results)
+      pure (join (map Builtin.fst results), mapMaybe Builtin.snd results)
 
-    -- Worklist analogue of the original all-reachable fixpoint: round 1
-    -- drains everything (`dirty` starts as all of `reachable`); afterwards
-    -- a function is re-drained only when its inference inputs moved —
-    -- plans and callback sigs are fixed here, so that means (a) a
-    -- constructor referenced by its body became natural-live (the
-    -- `inferConCaseExpr` narrowing gate flips off), or (b) a function it
-    -- references changed its inferred type (callers consume callee types),
-    -- the latter gated on the live set having grown in the same round,
-    -- mirroring the original loop which also stopped propagating type
-    -- ripples once a full pass added nothing.  Partial re-drains are exact
-    -- here because contributions accumulate by UNION and a site's
-    -- `needsNatural` verdict depends only on the site and the static
-    -- conPlan — once observed, its contribution is permanent.
-    loop : SortedMap Name (SortedSet Name) -> SortedSet Name -> SortedSet Name -> Core (SortedSet Name)
-    loop revDeps dirty current =
+    -- Reachability closure over the rewritten call graph: a function is LIVE
+    -- only when reachable from a root (`main`/export) through references in
+    -- LIVE bodies.  `growReachable live refsByFn seeds` extends `live` with
+    -- everything reachable from the refs of `seeds`.  Seeding with only the
+    -- changed (re-drained, live) functions keeps liveness INCREMENTAL: the
+    -- initial call seeds with the roots (full closure), later rounds
+    -- re-explore only the few dirty live functions — reachability can only
+    -- GROW, and only when a live body gains a (spec-call) reference, so
+    -- exploring from those bodies transitively closes the new reachable set.
+    growReachable : SortedSet Name -> SortedMap Name (SortedSet Name) -> List Name -> SortedSet Name
+    growReachable live refsByFn seeds = go seeds live
+      where
+        go : List Name -> SortedSet Name -> SortedSet Name
+        go [] visited = visited
+        go (f :: fs) visited =
+          let nbrs  = SortedSet.toList (fromMaybe SortedSet.empty (SortedMap.lookup f refsByFn))
+              fresh = filter (\x => not (SortedSet.contains x visited)) nbrs
+          in go (fresh ++ fs) (foldl (\v, x => SortedSet.insert x v) visited fresh)
+
+    -- Worklist fixpoint with PERSISTENT per-node state, processed
+    -- INCREMENTALLY.  Draining re-runs only dirty functions: (a) one whose
+    -- referenced constructor became natural-live (its `inferConCaseExpr`
+    -- narrowing gate flips off), or (b) one referencing a function whose
+    -- inferred type changed.  `sitesByFn`/`refsByFn` accumulate the full
+    -- graph; `liveFns` (the reachability closure from the roots) and the
+    -- natural-live set are grown incrementally rather than recomputed each
+    -- round — `needsNatural` is a pure function of a site and the fixed
+    -- `conPlan`, so a site's verdict never changes, and reachability only
+    -- grows.  Each round contributes `needsNatural` for the sites of the
+    -- nodes TOUCHED this round: re-drained dirty nodes that are live, plus
+    -- newly-live nodes.  Contributions are UNIONed (never removed) — once a
+    -- constructor is observed natural-live in a LIVE body it stays live,
+    -- which handles the slot-flipping non-monotonicity and gives
+    -- termination; the union covers the converged rewriting emission uses,
+    -- so a typed read implies no live function builds the natural class.
+    -- (The full-graph rescan this replaced made `naturalConsLive` ~50% of
+    -- the build.)
+    loop : SortedMap Name (SortedSet Name) -> SortedSet Name -> SortedSet Name
+        -> SortedMap Name (List (Name, List InferredType)) -> SortedMap Name (SortedSet Name)
+        -> SortedSet Name -> Core (SortedSet Name, SortedSet Name)
+    loop revDeps dirty current sitesByFn refsByFn liveFns =
       case SortedSet.toList dirty of
-        [] => pure current
+        [] => pure (current, liveFns)
         _ => do
           let names = filter (\n => SortedSet.contains n dirty) reachable
-          (next, typeChanged) <- onePass current names
-          let delta = filter (\k => not (SortedSet.contains k current)) (SortedSet.toList next)
-          let merged = SortedSet.union current next
+          (nodes, typeChanged) <- onePass current names
+          let sitesByFn' = foldl (\m, (node, sites, _) => SortedMap.insert node sites m) sitesByFn nodes
+          let refsByFn'  = foldl (\m, (node, _, refs) => SortedMap.insert node refs m) refsByFn nodes
+          -- Grow the live set: reachability can only have gained edges from
+          -- the dirty functions that are already live, so re-explore from
+          -- just those (the first round seeds from the roots → full closure).
+          let liveFns' = growReachable liveFns refsByFn' (filter (\n => SortedSet.contains n liveFns) names)
+          let newlyLive = filter (\n => not (SortedSet.contains n liveFns)) (SortedSet.toList liveFns')
+          -- dirty-now-live ++ newly-live; a node appearing in both is fine
+          -- (the contribution is a set), so no quadratic `nub`.
+          let touched = filter (\n => SortedSet.contains n liveFns') names ++ newlyLive
+          let contribSites = touched >>= \n => fromMaybe [] (SortedMap.lookup n sitesByFn')
+          let contribution = SortedSet.fromList (mapMaybe needsNatural contribSites)
+          let merged = SortedSet.union current contribution
+          let delta = filter (\k => not (SortedSet.contains k current)) (SortedSet.toList merged)
           let dirtyFromLive = unionAll (map (revDepsOf revDeps) delta)
           let dirtyFromTypes = if isNil delta
                                  then SortedSet.empty
                                  else unionAll (map (revDepsOf revDeps) typeChanged)
-          loop revDeps (SortedSet.union dirtyFromLive dirtyFromTypes) merged
+          loop revDeps (SortedSet.union dirtyFromLive dirtyFromTypes) merged sitesByFn' refsByFn' liveFns'
 
 -- For each spec entry with a TCon-family interface, find every sibling
 -- DCon's natural class and register that natural class to implement the
@@ -3931,13 +4127,13 @@ compileToJvmBytecode outputDirectory outputFile term = do
     callbackSigs <- computeCallbackSlotSigs nameFcDefs
     traverse_ (\(_, r) => setCallbackSlotSigs {stateRef = r} callbackSigs) (SortedMap.toList stateRefsMap)
     (plan, conPlan) <- buildSpecialisationPlan programName namedDefsByName stateRefsMap reachable
-    natLive <- computeNaturalConsLive namedDefsByName stateRefsMap plan conPlan reachable
+    (natLive, liveFns) <- computeNaturalConsLive namedDefsByName stateRefsMap plan conPlan reachable (SortedSet.fromList rootNames)
     natIfaces <- computeNaturalToTConIfaces programName conPlan namedDefsByName stateRefsMap plan reachable
     preRegisterSpecs plan
     preRegisterConstructorSpecs conPlan
     preRegisterCallbackInterfaces programName plan callbackSigs
     let reachableNameFcStateRefs = filter (\(n, _, _) => SortedSet.contains n reachableSet) nameFcStateRefs
-    assembleNameFcStateRefs plan conPlan natLive natIfaces namedDefsByName reachableNameFcStateRefs
+    assembleNameFcStateRefs plan conPlan natLive natIfaces liveFns namedDefsByName reachableNameFcStateRefs
     coreLift $ do
         exportDefs $ mapMaybe (getExport noMangleMap . fst) allDefs
         mainAsmState <- AsmState.fromIdrisName mainFunctionName

--- a/src/Compiler/Jvm/Codegen.idr
+++ b/src/Compiler/Jvm/Codegen.idr
@@ -3406,6 +3406,92 @@ buildSpecialisationPlan programName defs stateRefs reachable = iterate
     Plans : Type
     Plans = (SpecialisationPlan, ConSpecialisationPlan)
 
+    -- The family interface (or RECORD/UNIT spec class) a single
+    -- construction site contributes to its enclosing function's return
+    -- type, paired with the construction's parent TCon.  `Nothing` for
+    -- synthetic shapes (skipped — their natural class is always live, so a
+    -- family-typed read is never sound; see §12/§14), sites with no
+    -- matching spec, and ordinary DCons that haven't pinned an
+    -- instantiation interface (`tconClassName == ""`).
+    returnFamilyOf : ConSpecialisationPlan -> ConInfo -> Name -> List InferredType
+                  -> Core (Maybe (Name, InferredType))
+    returnFamilyOf conPlan conInfo conName paramTypes =
+      if isJust (syntheticTConName conInfo) then pure Nothing
+      else case matchConSpec conName paramTypes conPlan of
+        Nothing => pure Nothing
+        Just sc =>
+          let mR = if isRecordCon conInfo
+                     then Just (IRef sc.specClassName Class [])
+                     else if sc.tconClassName /= ""
+                            then Just (IRef sc.tconClassName Interface [])
+                            else Nothing
+          in case mR of
+            Nothing => pure Nothing
+            Just r => do
+              mTc <- findTConForDCon conName
+              pure $ (\tc => (tc, r)) <$> mTc
+      where
+        slotMatch : InferredType -> InferredType -> Bool
+        slotMatch spec arg = if isPrimitive spec then spec == arg else not (isPrimitive arg)
+        matchConSpec : Name -> List InferredType -> ConSpecialisationPlan
+                    -> Maybe SpecialisedConstructor
+        matchConSpec n argTypes plan = do
+          entries <- SortedMap.lookup n plan
+          find (\sc => length sc.paramTypes == length argTypes
+                       && all (uncurry slotMatch) (zip sc.paramTypes argTypes)) entries
+
+    -- Family-typed return refinement (design doc §14).  When a natural
+    -- producer's declared result is a single TCon `T` and every
+    -- data-carrying construction in its body belongs to ONE family
+    -- instantiation of `T`, refine the function's return type from Object
+    -- to that family interface (or, for a RECORD/UNIT producer, the lone
+    -- DCon spec class).  The refined type persists on the per-name
+    -- AsmState — read back next pass, by the natLive fixpoint, and by
+    -- final assembly (`assembleNameFcStateRefs` seeds from
+    -- `getCurrentFunction`) — and propagates to callers via
+    -- `findFunctionType`, so a consumer of `f`'s result earns a
+    -- family-typed parameter spec whose pattern match reads with typed
+    -- accessors instead of boxed `getProperty`.
+    --
+    -- Soundness rests on the result-type gate: every value the function
+    -- returns is a `T`, and every member of an active family
+    -- instantiation implements its interface (siblings via
+    -- `computeNaturalToTConIfaces`), so an Object-typed tail (a returned
+    -- `Nil`/parameter) is cast to the interface at `areturn` and succeeds.
+    -- Conservative: a body building more than one instantiation of `T`, a
+    -- non-TCon result head, or any synthetic-shape construction leaves the
+    -- return unrefined.  Idempotent, so the fixpoint converges.
+    refineNaturalReturn : {auto stateRef : Ref AsmState AsmState}
+                       -> ConSpecialisationPlan -> Name -> Core ()
+    refineNaturalReturn conPlan name = do
+      fn <- getCurrentFunction
+      let fty = inferredFunctionType fn
+      -- Only the generic Object return is a refinement candidate;
+      -- `isObjectType` is true for `inferredObjectType`/`IUnknown` and
+      -- false once already refined to an `IRef T$F`, so this is idempotent
+      -- and the fixpoint converges.
+      when (isObjectType (returnType fty)) $ do
+        conLog <- getConSiteLog
+        -- Dedup construction sites by (DCon, paramTypes): cross-pass
+        -- accumulation re-adds each site, and `paramTypes` is ref-
+        -- normalised so the keys are stable.
+        let sites = nubBy (\(n1, _, p1), (n2, _, p2) => n1 == n2 && p1 == p2)
+                          (map (\(_, n, ci, _, ps) => (n, ci, ps)) conLog)
+        candidates <- traverse (\(n, ci, ps) => returnFamilyOf conPlan ci n ps) sites
+        case mapMaybe id candidates of
+          [] => pure ()
+          families => do
+            Just retTcon <- getResultTypeCon name
+              | Nothing => pure ()
+            let matching = nub $ mapMaybe (\(tc, r) => if tc == retTcon then Just r else Nothing) families
+            case matching of
+              [r] => do
+                let fn' = { inferredFunctionType := { returnType := r } fty } fn
+                setCurrentFunction fn'
+                jname <- getRootMethodName
+                coreLift $ addFunction jname fn'
+              _ => pure ()
+
     step : PlanState -> Name -> Core (PlanState, StepEffects)
     step ps name = do
       let nameStr = jvmSimpleName name
@@ -3421,6 +3507,11 @@ buildSpecialisationPlan programName defs stateRefs reachable = iterate
       setConSpecialisationPlan {stateRef = asmStateRef} ps.conPlan
       inferFunctionType (Just initialFunctionType) def
       inferDef
+      -- Refine the natural return type to a family interface when the body
+      -- provably produces one TCon instantiation; mutates the per-name
+      -- AsmState so the change is observed by `functionType` below (=>
+      -- naturalTypeChanged => re-iterate) and propagates to callers.
+      refineNaturalReturn ps.conPlan name
       let functionType = inferredFunctionType !getCurrentFunction
       let naturalTypeChanged = functionType /= initialFunctionType
       -- Function-spec discovery from the natural's call sites.  Previously

--- a/src/Compiler/Jvm/Optimizer.idr
+++ b/src/Compiler/Jvm/Optimizer.idr
@@ -1371,8 +1371,24 @@ mutual
         -- runs specialised (zipWith/takeUntil kept allocating boxed CONS
         -- cells from their second element on).
         let normalizedArgTypes = map (\ty => if ty == IUnknown then inferredObjectType else ty) inferredArgTypes
-        updateState { callSiteLog $= ((fc, idrisName, MkInferredFunctionType retType normalizedArgTypes) :: ) }
-        pure retType
+        -- Spec-return propagation (design doc §14).  If a registered spec of
+        -- this callee matches the call's argument types, the call WILL be
+        -- rewritten to that spec by `rewriteSpecCalls` (same parameter-type
+        -- match), so this expression's runtime type is the spec's
+        -- (possibly family-refined) return — not the natural Object return.
+        -- Using it here is how a parametric producer's concrete-instantiation
+        -- family interface (`Tree$F$I` for `mkTree$sp0(int)`) reaches the
+        -- consumer's call-site log and earns the consumer a family-typed
+        -- parameter spec.  Inference and emission agree: emission lowers the
+        -- already-rewritten `f$sp0` head and reads the same refined type via
+        -- `findFunctionType`.
+        plan <- getSpecialisationPlan
+        let effectiveRet = fromMaybe retType $ do
+              specs <- SortedMap.lookup idrisName plan
+              spec  <- find (\s => s.type.parameterTypes == normalizedArgTypes) specs
+              pure spec.type.returnType
+        updateState { callSiteLog $= ((fc, idrisName, MkInferredFunctionType effectiveRet normalizedArgTypes) :: ) }
+        pure effectiveRet
     inferExprApp (NmApp _ inner@(NmApp _ lambdaVariable@(NmLocal _ var) [x]) [y]) = do
         -- Inference mirror of the arity-2 typed-apply emission: `f x y`
         -- (nested unary application) on a variable statically typed as a
@@ -1772,6 +1788,29 @@ namespace TermType
           Ref _ _ tyName => Just tyName
           _ => Nothing
 
+  -- Count the Pi binders of a TCon's type — its parameter+index arity
+  -- (`Box : Type` -> 0, `WithBounds : Type -> Type` -> 1, `Vect : Nat ->
+  -- Type -> Type` -> 2).  `refineNaturalReturn` (Codegen.idr) only refines
+  -- a return type when this is 0: a non-parametric, non-indexed TCon has
+  -- exactly ONE runtime instantiation, so the natural function, every spec
+  -- that inherits its refined return via the call-site log, and every
+  -- caller all agree on the single family/spec class.  A parametric TCon
+  -- (`WithBounds ty`) can have a spec build a different instantiation
+  -- (`MkBounded$I$I$L`) than the natural's refined return
+  -- (`MkBounded$L$I$L`) — a `Bad return type` VerifyError.  `Nothing` when
+  -- the type is missing.
+  export
+  getTypeConArity : {auto c : Ref Ctxt Defs} -> {auto s : Ref Syn SyntaxInfo}
+                  -> Name -> Core (Maybe Nat)
+  getTypeConArity name = do
+      Just term <- getTypeTerm name
+        | Nothing => pure Nothing
+      pure $ Just $ countPis term
+    where
+      countPis : {vars : _} -> Term vars -> Nat
+      countPis (Bind _ _ (Pi _ _ _ _) sc) = S (countPis sc)
+      countPis _ = Z
+
   -- Look up all data constructors of a type constructor.  Returns the
   -- empty list when the name isn't a TCon or has no recorded datacons.
   export
@@ -2086,6 +2125,7 @@ inferFunctionType (Just initialFunctionType) (MkNmFun args expr) = do
   coreLift $ addFunction jname function
   resetScope
   resetCallSiteLog
+  setInferredReturnType IUnknown
   scopeIndex <- newScopeIndex
   let (_, lineStart, lineEnd) = getSourceLocation expr
   allVariableTypes <- coreLift $ Map.newTreeMap {key=Int} {value=InferredType}
@@ -2163,7 +2203,12 @@ inferDef = do
         resetScope
         size <- coreLift $ Collection.size {elemTy=Scope, obj=Collection Scope} $ believe_me (scopes function)
         setScopeCounter size
-        ignore $ inferExpr expr
+        -- Capture the body's inferred return type (otherwise discarded) so
+        -- family-typed return refinement can use it — it already reflects the
+        -- spec plan via inferExprApp, covering pass-through producers
+        -- (`f x = g x`) the construction-site scan can't see.
+        bodyReturnType <- inferExpr expr
+        setInferredReturnType bodyReturnType
         updateScopeVariableTypes
         -- Rewire any call site whose inferred argument types match a $sp
         -- variant from the plan.  Persists the rewritten body BOTH on the

--- a/src/Compiler/Jvm/Optimizer.idr
+++ b/src/Compiler/Jvm/Optimizer.idr
@@ -1747,6 +1747,31 @@ namespace TermType
           Ref _ _ tyName => Just tyName
           _ => Nothing
 
+  -- Walk the binders of any name's type term to its result type, then
+  -- return the head `Ref` — for a FUNCTION that's the type constructor of
+  -- its return type (`Int -> Tree` -> `Tree`).  Used by the family-typed
+  -- return-type refinement (`refineNaturalReturn` in Codegen.idr) as the
+  -- soundness gate: when a producer's result is a single TCon `T`, every
+  -- value it returns is a `T`, so the return may be typed as a family
+  -- interface that every member of `T` implements.  `Nothing` when the
+  -- type is missing or the result head isn't a `Ref` (type variable,
+  -- function type, primitive).
+  export
+  getResultTypeCon : {auto c : Ref Ctxt Defs} -> {auto s : Ref Syn SyntaxInfo}
+                   -> Name -> Core (Maybe Name)
+  getResultTypeCon name = do
+      Just term <- getTypeTerm name
+        | Nothing => pure Nothing
+      pure $ extractTCon term
+    where
+      extractTCon : {vars : _} -> Term vars -> Maybe Name
+      extractTCon (Bind _ _ (Pi _ _ _ _) sc) = extractTCon sc
+      extractTCon term =
+        let (fn, _) = getFnArgs term
+        in case fn of
+          Ref _ _ tyName => Just tyName
+          _ => Nothing
+
   -- Look up all data constructors of a type constructor.  Returns the
   -- empty list when the name isn't a TCon or has no recorded datacons.
   export

--- a/tests/jvm/conrecursiveslots/expected
+++ b/tests/jvm/conrecursiveslots/expected
@@ -6,7 +6,8 @@ Leaf implements Tree$F: OK
 sumLeft$sp(int, Tree$F) -> int: PRESENT
 sumLeft$sp Node alt: family checkcast + typed getRef1
 sumLeft$sp tail-rec: no Tree$F checkcast
-build construction: checkcast Tree$F before Node ctor
+build returns Tree$F: YES
+build recursion: typed self-call + Leaf-only cast
 IdrisList$Cons still present: OK
 11
 5050

--- a/tests/jvm/conrecursiveslots/run
+++ b/tests/jvm/conrecursiveslots/run
@@ -76,13 +76,24 @@ else
   echo "sumLeft\$sp tail-rec: no Tree\$F checkcast"
 fi
 
-# The construction site pays the (single) cast instead: build's untyped
-# recursive result is checkcast to Tree$F before the Node ctor.
-build_body=$(echo "$disassembly" | awk '/static java.lang.Object build\(/,/^$/')
-if echo "$build_body" | grep -qE 'checkcast.*Tree\$F'; then
-  echo "build construction: checkcast Tree\$F before Node ctor"
+# Family-typed return refinement (design doc §14): `build`'s result is the
+# single TCon `Tree` and its body builds only the `Node$I$L$L` family, so
+# its return type narrows from Object to the family interface `Tree$F`.
+build_body=$(echo "$disassembly" | awk '/Tree\$F build\(int\)/,/^$/')
+if echo "$build_body" | grep -qE 'Tree\$F build\(int\)'; then
+  echo "build returns Tree\$F: YES"
 else
-  echo "build construction: NO CONSTRUCTION CAST"
+  echo "build returns Tree\$F: NO (still Object)"
+fi
+
+# The recursive self-call now returns Tree$F directly, so it feeds the
+# Node ctor's recursive slot with NO checkcast — only the nullary `Leaf`
+# branches pay the Object->Tree$F cast (at areturn / into the Leaf slot).
+if echo "$build_body" | grep -qE 'invokestatic.*build:\(I\)LM_Main/Tree\$F' \
+   && echo "$build_body" | grep -qE 'checkcast.*Tree\$F'; then
+  echo "build recursion: typed self-call + Leaf-only cast"
+else
+  echo "build recursion: UNEXPECTED SHAPE"
 fi
 
 # Bootstrap-compat smoke test.

--- a/tests/jvm/conreturnfamily/Spec.idr
+++ b/tests/jvm/conreturnfamily/Spec.idr
@@ -26,5 +26,45 @@ useBox : Box -> Int
 useBox Empty = 0
 useBox (Full a b c) = a + b + c
 
+-- Regression guard 1: a RECORD must NOT be return-refined — only multi-con
+-- family INTERFACES are valid targets.  A record has no marker interface,
+-- only its concrete DCon spec class, whose identity is per-site field-type
+-- inference (`MkPFR$L$L$I` vs natural `MkPFR`).  Refining a record return
+-- commits consumers to one class → `ClassCastException`/`VerifyError` when a
+-- differently-inferred sibling flows in (the self-host `Text.Bounded` and
+-- `Idris.Package.partitionOpts` failures).  Both a PARAMETRIC record
+-- (`Wrap a`) and a NON-PARAMETRIC one (`NRec`) must keep an Object return.
+record Wrap a where
+  constructor MkWrap
+  here : a
+  lo : Int
+  hi : Int
+
+wrap : a -> Wrap a
+wrap x = MkWrap x 1 2
+
+-- Reads the parametric `here` field too, so the `int` instantiation
+-- (`MkWrap$I$I$I`) is genuinely forced.
+useWrap : Int -> Int
+useWrap n = let w = wrap n in here w + lo w + hi w
+
+-- A genuine non-parametric RECORD: THREE fields, so `calcListy`/`calcMaybe`
+-- don't reinterpret it as a synthetic CONS/JUST cell.  Its spec class is
+-- per-site field-type inference, so it must NOT be return-refined (§14).
+record NRec where
+  constructor MkNRec
+  a : Int
+  b : Int
+  c : Int
+
+mkRec : Int -> NRec
+mkRec n = MkNRec n (n + 1) (n + 2)
+
+useRec : Int -> Int
+useRec n = let r = mkRec n in a r + b r + c r
+
 main : IO ()
-main = printLn (useBox (mkBox 5))
+main = do
+  printLn (useBox (mkBox 5))
+  printLn (useWrap 7)
+  printLn (useRec 9)

--- a/tests/jvm/conreturnfamily/Spec.idr
+++ b/tests/jvm/conreturnfamily/Spec.idr
@@ -1,0 +1,30 @@
+module Main
+
+-- Family-typed return propagation (design doc §14).
+--
+-- `Box` is an ordinary multi-constructor DATACON family: the data-carrying
+-- `Full` has three Int fields (so it escapes the listy/maybe shapes that
+-- become shared `_builtin` intrinsics).  `mkBox` is a PRODUCER whose
+-- declared result is the single TCon `Box`; its body builds only
+-- `Full$I$I$I` cells (and the nullary `Empty`), so the return-type
+-- refinement narrows `mkBox`'s return from Object to the family interface
+-- `Box$F`.
+--
+-- The CONSUMER `useBox` is fed `mkBox`'s result at a call site that is NOT
+-- a direct construction (`useBox (mkBox 5)`).  Only because `mkBox`'s
+-- refined return advertises `Box$F` does that call log a family-typed
+-- argument, earning `useBox$sp(Box$F)` whose `Full` alt reads the fields
+-- with typed `getInt0/1/2` accessors instead of boxed `getProperty` +
+-- `Conversion.toInt`.
+data Box = Empty | Full Int Int Int
+
+mkBox : Int -> Box
+mkBox 0 = Empty
+mkBox n = Full n (n + 1) (n + 2)
+
+useBox : Box -> Int
+useBox Empty = 0
+useBox (Full a b c) = a + b + c
+
+main : IO ()
+main = printLn (useBox (mkBox 5))

--- a/tests/jvm/conreturnfamily/expected
+++ b/tests/jvm/conreturnfamily/expected
@@ -1,0 +1,9 @@
+Family interface Box$F: PRESENT
+Empty implements Box$F: OK
+Full$I$I$I fields: int x3
+Full$I$I$I accessors: getInt0 + getInt1 + getInt2
+mkBox returns Box$F: YES
+useBox$sp(Box$F) -> int: PRESENT
+useBox$sp Full alt: family checkcast + typed getInt (no getProperty)
+IdrisList$Cons still present: OK
+18

--- a/tests/jvm/conreturnfamily/expected
+++ b/tests/jvm/conreturnfamily/expected
@@ -5,5 +5,9 @@ Full$I$I$I accessors: getInt0 + getInt1 + getInt2
 mkBox returns Box$F: YES
 useBox$sp(Box$F) -> int: PRESENT
 useBox$sp Full alt: family checkcast + typed getInt (no getProperty)
+wrap (parametric record) spec return: Object (not refined)
+mkRec (non-param record) return: Object (not refined)
 IdrisList$Cons still present: OK
 18
+10
+30

--- a/tests/jvm/conreturnfamily/run
+++ b/tests/jvm/conreturnfamily/run
@@ -67,6 +67,25 @@ else
   echo "useBox\$sp Full alt: NO TYPED READ"
 fi
 
+# Regression guard: RECORD producers must NOT be return-refined to a concrete
+# record spec class (else a consumer inherits one and a differently-inferred
+# sibling CCEs).  The parametric `wrap`'s natural is dead (useWrap routes to
+# wrap$sp0) and DCE'd; the LIVE `wrap$sp0` must return Object, and no `wrap`
+# method may return a `MkWrap$...` spec class.  Non-parametric `mkRec` is
+# monomorphic — called directly, so its natural is live and retained.
+if echo "$disassembly" | grep -qE 'java\.lang\.Object wrap\$sp[0-9]+\(int\)' \
+   && ! echo "$disassembly" | grep -qE 'MkWrap\$[A-Z$]* wrap'; then
+  echo "wrap (parametric record) spec return: Object (not refined)"
+else
+  echo "wrap (parametric record) spec return: WRONGLY REFINED"
+fi
+if echo "$disassembly" | grep -qE 'java\.lang\.Object mkRec\(int\)' \
+   && ! echo "$disassembly" | grep -qE 'MkNRec\$[A-Z$]* mkRec\('; then
+  echo "mkRec (non-param record) return: Object (not refined)"
+else
+  echo "mkRec (non-param record) return: WRONGLY REFINED"
+fi
+
 # Bootstrap-compat smoke test.
 if find "$app" -name 'IdrisList$Cons.class' -print -quit 2>/dev/null | grep -q .; then
   echo "IdrisList\$Cons still present: OK"

--- a/tests/jvm/conreturnfamily/run
+++ b/tests/jvm/conreturnfamily/run
@@ -1,0 +1,77 @@
+rm -rf build
+
+$1 --no-banner --no-color --console-width 0 -o retfamily Spec.idr > /dev/null 2>&1
+
+app=build/exec/retfamily_app
+
+full_spec=$(find "$app" -name 'Full$I$I$I.class' -print -quit 2>/dev/null)
+box_iface=$(find "$app" -name 'Box$F.class' -print -quit 2>/dev/null)
+empty_class=$(find "$app" -name 'Empty.class' -print -quit 2>/dev/null)
+
+# Family interface exists and the nullary sibling implements it.
+if [ -f "$box_iface" ] && javap "$box_iface" 2>/dev/null | grep -q 'interface'; then
+  echo "Family interface Box\$F: PRESENT"
+else
+  echo "Family interface Box\$F: MISSING"
+fi
+
+if javap "$empty_class" 2>/dev/null | grep -q 'Box\$F'; then
+  echo "Empty implements Box\$F: OK"
+else
+  echo "Empty implements Box\$F: MISSING"
+fi
+
+# Full spec class: three int fields + typed accessors.
+full_members=$(javap -p "$full_spec" 2>/dev/null)
+if echo "$full_members" | grep -qE 'int property0;' \
+   && echo "$full_members" | grep -qE 'int property1;' \
+   && echo "$full_members" | grep -qE 'int property2;'; then
+  echo "Full\$I\$I\$I fields: int x3"
+else
+  echo "Full\$I\$I\$I fields: NOT TYPED"
+fi
+if echo "$full_members" | grep -qE 'public int getInt0\(\)' \
+   && echo "$full_members" | grep -qE 'public int getInt1\(\)' \
+   && echo "$full_members" | grep -qE 'public int getInt2\(\)'; then
+  echo "Full\$I\$I\$I accessors: getInt0 + getInt1 + getInt2"
+else
+  echo "Full\$I\$I\$I accessors: MISSING"
+fi
+
+main_class=$(find "$app" -path '*retfamily/Main.class' -print -quit)
+disassembly=$(javap -c -p "$main_class" 2>/dev/null)
+
+# THE KEY ASSERTION: `mkBox` returns the family interface, not Object.
+# Without return-type refinement this descriptor is `java.lang.Object`.
+if echo "$disassembly" | grep -qE 'Box\$F mkBox\(int\)'; then
+  echo "mkBox returns Box\$F: YES"
+else
+  echo "mkBox returns Box\$F: NO (still Object)"
+fi
+
+# The consumer spec exists, fed purely by `mkBox`'s refined return.
+usebox_body=$(echo "$disassembly" | awk '/static int useBox\$sp[0-9]+\(.*Box\$F\)/,/^$/')
+if [ -n "$usebox_body" ]; then
+  echo "useBox\$sp(Box\$F) -> int: PRESENT"
+else
+  echo "useBox\$sp(Box\$F) -> int: MISSING"
+fi
+
+# ...and its Full alt reads the fields via typed accessors (no boxed
+# getProperty / Conversion.toInt on the field path).
+if echo "$usebox_body" | grep -q 'checkcast.*Full\$I\$I\$I' \
+   && echo "$usebox_body" | grep -qE 'getInt0:\(\)' \
+   && ! echo "$usebox_body" | grep -qE 'getProperty'; then
+  echo "useBox\$sp Full alt: family checkcast + typed getInt (no getProperty)"
+else
+  echo "useBox\$sp Full alt: NO TYPED READ"
+fi
+
+# Bootstrap-compat smoke test.
+if find "$app" -name 'IdrisList$Cons.class' -print -quit 2>/dev/null | grep -q .; then
+  echo "IdrisList\$Cons still present: OK"
+else
+  echo "IdrisList\$Cons MISSING (broke bootstrap compat)"
+fi
+
+./build/exec/retfamily${IDRIS_EXEC_EXT}

--- a/tests/jvm/conreturnfamilypoly/Spec.idr
+++ b/tests/jvm/conreturnfamilypoly/Spec.idr
@@ -1,0 +1,18 @@
+module Main
+
+-- Parametric, family-eligible sum type.
+data Tree a = Leaf | Node a (Tree a) (Tree a)
+
+-- POLYMORPHIC producer; the `Int` call site forces mkTree$sp0(int), which
+-- (with spec-return propagation) returns the concrete family interface
+-- Tree$F$I instead of Object.
+mkTree : a -> Tree a
+mkTree x = Node x Leaf Leaf
+
+-- Consumer fed purely by the producer's result (not a direct construction).
+sumTree : Tree Int -> Int
+sumTree Leaf = 0
+sumTree (Node x l r) = x + sumTree l + sumTree r
+
+main : IO ()
+main = printLn (sumTree (mkTree 7))

--- a/tests/jvm/conreturnfamilypoly/expected
+++ b/tests/jvm/conreturnfamilypoly/expected
@@ -1,0 +1,8 @@
+Family interface Tree$F$I: PRESENT
+mkTree (natural, polymorphic): eliminated (dead)
+mkTree$sp0 returns Tree$F$I: YES
+sumTree$sp0(Tree$F$I) -> int: PRESENT
+sumTree$sp0 reads: typed (getInt0/getRef, no getProperty)
+sumTree$sp0 recursion: stays specialised
+natural Node: never constructed
+7

--- a/tests/jvm/conreturnfamilypoly/run
+++ b/tests/jvm/conreturnfamilypoly/run
@@ -1,0 +1,65 @@
+rm -rf build
+
+$1 --no-banner --no-color --console-width 0 -o pf Spec.idr > /dev/null 2>&1
+
+app=build/exec/pf_app
+mc=$(find "$app" -path '*pf/Main.class' -print -quit 2>/dev/null)
+dis=$(javap -c -p "$mc" 2>/dev/null)
+
+# The PARAMETRIC family interface for the Int instantiation exists.
+if [ -f "$(find "$app" -name 'Tree$F$I.class' -print -quit 2>/dev/null)" ]; then
+  echo "Family interface Tree\$F\$I: PRESENT"
+else
+  echo "Family interface Tree\$F\$I: MISSING"
+fi
+
+# Spec-return propagation across a parametric instantiation: the POLYMORPHIC
+# producer's natural is never refined (it serves all instantiations) AND, with
+# every caller routed to mkTree$sp0, it is unreachable, so DCE eliminates it.
+if echo "$dis" | grep -qE 'mkTree\(java\.lang\.Object\)'; then
+  echo "mkTree (natural, polymorphic): NOT ELIMINATED"
+else
+  echo "mkTree (natural, polymorphic): eliminated (dead)"
+fi
+if echo "$dis" | grep -qE 'Tree\$F\$I mkTree\$sp[0-9]+\(int\)'; then
+  echo "mkTree\$sp0 returns Tree\$F\$I: YES"
+else
+  echo "mkTree\$sp0 returns Tree\$F\$I: NO"
+fi
+
+# The consumer earns a family-typed parameter spec, fed purely by the
+# producer's spec return (the argument is a call, not a construction).
+sumbody=$(echo "$dis" | awk '/int sumTree\$sp[0-9]+\(.*Tree\$F\$I\)/,/^$/')
+if [ -n "$sumbody" ]; then
+  echo "sumTree\$sp0(Tree\$F\$I) -> int: PRESENT"
+else
+  echo "sumTree\$sp0(Tree\$F\$I) -> int: MISSING"
+fi
+
+# Liveness-aware naturalConsLive: the natural `mkTree` is never called (every
+# caller routes to mkTree$sp0), so natural `Node` is dead and the consumer
+# reads with TYPED accessors (getInt0 / getRef) instead of boxed getProperty.
+if echo "$sumbody" | grep -qE 'getInt0:\(\)' \
+   && echo "$sumbody" | grep -qE 'getRef[12]:\(\)' \
+   && ! echo "$sumbody" | grep -qE 'getProperty'; then
+  echo "sumTree\$sp0 reads: typed (getInt0/getRef, no getProperty)"
+else
+  echo "sumTree\$sp0 reads: STILL BOXED"
+fi
+
+# ...and the recursion stays specialised (the typed getRef returns Tree$F$I).
+if echo "$sumbody" | grep -qE 'invokestatic.*sumTree\$sp[0-9]+:\(LM_Main/Tree\$F\$I' \
+   && ! echo "$sumbody" | grep -qE 'invokestatic.*sumTree:\(Ljava'; then
+  echo "sumTree\$sp0 recursion: stays specialised"
+else
+  echo "sumTree\$sp0 recursion: escapes to natural"
+fi
+
+# Natural Node is never constructed anywhere reachable.
+if echo "$dis" | grep -qE 'new .*// class M_Main/Node;'; then
+  echo "natural Node: CONSTRUCTED (liveness failed)"
+else
+  echo "natural Node: never constructed"
+fi
+
+./build/exec/pf${IDRIS_EXEC_EXT}

--- a/tests/jvm/conreturnfamilyreach/Spec.idr
+++ b/tests/jvm/conreturnfamilyreach/Spec.idr
@@ -1,0 +1,21 @@
+module Main
+
+data Tree a = Leaf | Node a (Tree a) (Tree a)
+
+leafOf : a -> Tree a
+leafOf x = Node x Leaf Leaf
+
+-- Polymorphic; main calls viaOuter$sp0, so NATURAL viaOuter is dead. Its
+-- natural body references natural leafOf (x:Object matches no spec), so
+-- natural leafOf is referenced ONLY from dead code.
+viaOuter : a -> Tree a
+viaOuter x = leafOf x
+
+sumTree : Tree Int -> Int
+sumTree Leaf = 0
+sumTree (Node x l r) = x + sumTree l + sumTree r
+
+main : IO ()
+main = do
+  printLn (sumTree (Node 5 Leaf Leaf))   -- direct: earns sumTree$sp0(Tree$F$I)
+  printLn (sumTree (viaOuter 7))         -- forces viaOuter$sp0 -> natural viaOuter -> natural leafOf

--- a/tests/jvm/conreturnfamilyreach/expected
+++ b/tests/jvm/conreturnfamilyreach/expected
@@ -1,0 +1,5 @@
+sumTree$sp0(Tree$F$I): PRESENT
+sumTree$sp0 read: typed (reachability-precise liveness)
+natural Node: never constructed
+5
+7

--- a/tests/jvm/conreturnfamilyreach/run
+++ b/tests/jvm/conreturnfamilyreach/run
@@ -1,0 +1,37 @@
+rm -rf build
+
+$1 --no-banner --no-color --console-width 0 -o rt Spec.idr > /dev/null 2>&1
+
+app=build/exec/rt_app
+mc=$(find "$app" -path '*rt/Main.class' -print -quit 2>/dev/null)
+dis=$(javap -c -p "$mc" 2>/dev/null)
+
+# Reachability-precise liveness: natural `viaOuter` is dead (every caller
+# routes to viaOuter$sp0), and it is the ONLY referrer of natural `leafOf`.
+# A reachability closure (not "referenced anywhere") therefore marks natural
+# `leafOf` dead, so its natural `Node` construction does not count — and the
+# consumer `sumTree$sp0`, fed by a DIRECT `Node 5 ...` construction, reads
+# the int field with `getInt0` instead of boxed `getProperty`.  Under the
+# weaker all-refs liveness, natural leafOf would be "live" and this read
+# would be boxed.
+sumbody=$(echo "$dis" | awk '/int sumTree\$sp[0-9]+\(.*Tree\$F\$I\)/,/^$/')
+if [ -n "$sumbody" ]; then
+  echo "sumTree\$sp0(Tree\$F\$I): PRESENT"
+else
+  echo "sumTree\$sp0(Tree\$F\$I): MISSING"
+fi
+if echo "$sumbody" | grep -qE 'getInt0:\(\)' && ! echo "$sumbody" | grep -qE 'getProperty'; then
+  echo "sumTree\$sp0 read: typed (reachability-precise liveness)"
+else
+  echo "sumTree\$sp0 read: BOXED (liveness too conservative)"
+fi
+
+# natural leafOf is referenced only by the dead natural viaOuter; with
+# reachability it is dead, so natural Node is never constructed.
+if echo "$dis" | grep -qE 'new .*// class M_Main/Node;'; then
+  echo "natural Node: CONSTRUCTED"
+else
+  echo "natural Node: never constructed"
+fi
+
+./build/exec/rt${IDRIS_EXEC_EXT}

--- a/tests/jvm/hofspecialisation/expected
+++ b/tests/jvm/hofspecialisation/expected
@@ -5,7 +5,7 @@ HOF spec for hof: OK
 HOF spec for countdown: OK
 Typed apply in applyN spec: OK
 Typed lambda implementation: OK
-Natural applyN retained: OK
+Natural applyN (dead): eliminated
 1024
 54
 16

--- a/tests/jvm/hofspecialisation/run
+++ b/tests/jvm/hofspecialisation/run
@@ -58,12 +58,16 @@ else
   echo "Typed lambda implementation: MISSING"
 fi
 
-# 5. The natural method is retained alongside the spec (callers without a
-#    matching spec — polymorphic or external — keep invoking it).
+# 5. Dead-function elimination (design doc §14.3): every `applyN` caller in
+#    this program is rewritten to the typed spec, so the natural method is
+#    unreachable in the rewritten graph and is not emitted.  (The natural is
+#    retained whenever a LIVE caller — polymorphic, unspecialised, or
+#    external — still invokes it; e.g. monomorphic producers in
+#    conrecursiveslots, and every reachable natural in the self-host.)
 if echo "$methods" | grep -qE 'public static int applyN\(int, java.util.function.Function, int\);'; then
-  echo "Natural applyN retained: OK"
+  echo "Natural applyN (dead): NOT ELIMINATED"
 else
-  echo "Natural applyN retained: MISSING"
+  echo "Natural applyN (dead): eliminated"
 fi
 
 ./build/exec/spec${IDRIS_EXEC_EXT}


### PR DESCRIPTION
# Description

* Extends monomorphization so a function's return type can be refined to a TCon family interface (Box$F, Tree$F$I) and propagated across call chains. This lets a consumer that receives a value from a function call (not just a literal construction) read its fields with typed accessors (getInt0) instead of boxed getProperty + Conversion.toInt

